### PR TITLE
Fix MSVC2012 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,27 @@ if(SDK_GOOGLE_BREAKPAD AND WIN32)
 	include_directories("${SDK_GOOGLE_BREAKPAD}/src/")
 endif()
 
+if (WIN32 AND DEFINED MSVC_VERSION AND NOT ${MSVC_VERSION} LESS 1700)
+		find_path (WIN8_SDK_ROOT_DIR
+				Include/um/windows.h
+				PATHS
+						"$ENV{ProgramFiles}/Windows Kits/8.0"
+						"$ENV{ProgramFiles(x86)}/Windows Kits/8.0"
+						DOC "Windows 8 SDK root directory"
+		)
+
+		if (WIN8_SDK_ROOT_DIR)
+		  SET(CMAKE_LIBRARY_PATH "${WIN8_SDK_ROOT_DIR}/Lib/win8/um/x86")
+		endif ()
+	endif ()
+endif()
+
+if(WIN32 AND DEFINED MSVC_VERSION AND NOT ${MSVC_VERSION} LESS 1700)
+	SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
+	SET (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SAFESEH:NO")
+	SET (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /SAFESEH:NO")
+endif()
+
 if(UNIX)
     set(SDK_ENABLE_LIBEVDEV FALSE CACHE BOOL "libevdev virtual joystick protocol support (probably Linux only)")
 endif()


### PR DESCRIPTION
1) Look for Windows Kit (Platform SDK) -- provides opengl3 for QT5.
2) Specify link with SAFESEH:NO if using MSVC2012, since older
directinput lib (dx8?) fails to link with this enabled.

Could not test (only have MSVC2012 and qt5 installed at this point) but seems to fix build problems on my dev machine.
