### PR TITLE
MSVC 11 expects __declspec(dllexport) before return type.

### DIFF
--- a/opentrack-api/context.cpp
+++ b/opentrack-api/context.cpp
@@ -93,17 +93,17 @@ opentrack_ctx::~opentrack_ctx()
 extern "C"
 {
 
-const char** OPENTRACK_EXPORT opentrack_enum_trackers(opentrack ctx)
+OPENTRACK_EXPORT const char** opentrack_enum_trackers(opentrack ctx)
 {
     return const_cast<const char**>(ctx->list);
 }
 
-opentrack OPENTRACK_EXPORT opentrack_make_ctx(int argc, char** argv, void* window_parent)
+OPENTRACK_EXPORT opentrack  opentrack_make_ctx(int argc, char** argv, void* window_parent)
 {
     return new opentrack_ctx(argc, argv, window_parent);
 }
 
-void OPENTRACK_EXPORT opentrack_finalize_ctx(opentrack foo)
+OPENTRACK_EXPORT void  opentrack_finalize_ctx(opentrack foo)
 {
     delete foo;
 }

--- a/opentrack-api/opentrack.h
+++ b/opentrack-api/opentrack.h
@@ -38,20 +38,20 @@ enum opentrack_dof {
 };
 #endif
 
-opentrack OPENTRACK_EXPORT opentrack_make_ctx(int argc, char** argv, void* window_parent);
-void OPENTRACK_EXPORT opentrack_finalize_ctx(opentrack self);
+OPENTRACK_EXPORT opentrack opentrack_make_ctx(int argc, char** argv, void* window_parent);
+OPENTRACK_EXPORT void opentrack_finalize_ctx(opentrack self);
 
 /* no need to free the return value; invalid to modify it */
-const char** OPENTRACK_EXPORT opentrack_enum_trackers(opentrack self);
+OPENTRACK_EXPORT const char** opentrack_enum_trackers(opentrack self);
 
 /*
  * don't `opentrack_tracker_tick an unstarted tracker, it's invalid to do so
  * it's also invalid to start a finalized tracker
  */
-opentrack_tracker OPENTRACK_EXPORT opentrack_make_tracker(opentrack ctx, const char* name);
-void OPENTRACK_EXPORT opentrack_tracker_start(opentrack self, opentrack_tracker tracker);
-int OPENTRACK_EXPORT opentrack_tracker_tick(opentrack_tracker tracker, double* headpose);
-void OPENTRACK_EXPORT opentrack_finalize_tracker(opentrack_tracker tracker);
+OPENTRACK_EXPORT opentrack_tracker opentrack_make_tracker(opentrack ctx, const char* name);
+OPENTRACK_EXPORT void  opentrack_tracker_start(opentrack self, opentrack_tracker tracker);
+OPENTRACK_EXPORT int opentrack_tracker_tick(opentrack_tracker tracker, double* headpose);
+OPENTRACK_EXPORT void opentrack_finalize_tracker(opentrack_tracker tracker);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This fixes compilation on MSVC 11 (2012) Express. Apparently the compiler expects __declspec(dllexport) first, before the return type. For some reason this was only generating errors on lines 45 and 96 (the const char*\* return types), but I changed it everywhere in these two files (context.cpp and opentrack.h) for consistency.  

Please test against earlier/later versions of MSVC, since 11 is all I have installed. I may add MSVC 2013 soon, will test against that then.
