### PR TITLE
Small improvements to the x-plane plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,13 +199,13 @@ if(SDK_XPLANE)
         SET_TARGET_PROPERTIES(opentrack-xplane-plugin
             PROPERTIES LINK_FLAGS
             "-Wl,--version-script=${CMAKE_SOURCE_DIR}/x-plane-plugin/version-script.txt -shared -rdynamic -nodefaultlibs -undefined_warning -fPIC"
-            COMPILE_FLAGS "-Wall -O2 -pipe -fPIC -DLIN -DXPLM210"
+            COMPILE_FLAGS "-Wall -O2 -pipe -fPIC -DLIN -DXPLM200 -DXPLM210"
             LIBRARY_OUTPUT_NAME "opentrack.xpl"
             PREFIX "" SUFFIX "")
     endif()
     if(APPLE)
         SET_TARGET_PROPERTIES(opentrack-xplane-plugin PROPERTIES
-                              COMPILE_FLAGS "-iframework ${SDK_XPLANE}/Libraries/Mac/ -DAPL -DXPLM210 -framework XPLM -framework XPWidgets"
+                              COMPILE_FLAGS "-iframework ${SDK_XPLANE}/Libraries/Mac/ -DAPL -DXPLM200 -DXPLM210 -framework XPLM -framework XPWidgets"
                               LINK_FLAGS "-F${SDK_XPLANE}/Libraries/Mac/ -framework XPLM -framework XPWidgets")
     endif()
     if(UNIX AND NOT APPLE)

--- a/opentrack/plugin-support.hpp
+++ b/opentrack/plugin-support.hpp
@@ -115,7 +115,8 @@ struct dylib {
                 {
                     fprintf(stderr, "Error, ignoring: %s\n", err);
                     fflush(stderr);
-                    dlclose(handle);
+                    if (handle)
+                        dlclose(handle);
                     handle = nullptr;
                     return true;
                 }
@@ -138,6 +139,7 @@ struct dylib {
                 return;
         } else {
             (void) _foo::err(handle);
+            return;
         }
 #endif
     

--- a/x-plane-plugin/plugin.c
+++ b/x-plane-plugin/plugin.c
@@ -118,6 +118,10 @@ static int TrackToggleHandler( XPLMCommandRef inCommand,
     {
         //Enable
         XPLMRegisterFlightLoopCallback(write_head_position, -1.0, NULL);
+
+        // Reinit the offsets when we re-enable the plugin
+        if ( !translation_disabled )
+            reinit_offset();
     }
     else
     {
@@ -133,6 +137,11 @@ static int TranslationToggleHandler( XPLMCommandRef inCommand,
                                      void * inRefCon )
 {
     translation_disabled = !translation_disabled;
+    if (!translation_disabled)
+    {
+        // Reinit the offsets when we re-enable the translations so that we can "move around"
+        reinit_offset();
+    }
     return 0;
 }
 

--- a/x-plane-plugin/plugin.c
+++ b/x-plane-plugin/plugin.c
@@ -10,6 +10,7 @@
 #include <XPLMPlugin.h>
 #include <XPLMDataAccess.h>
 #include <XPLMProcessing.h>
+#include <XPLMUtilities.h>
 
 #ifndef PLUGIN_API
 #define PLUGIN_API
@@ -39,6 +40,9 @@ static PortableLockedShm* lck_posix = NULL;
 static WineSHM* shm_posix = NULL;
 static void *view_x, *view_y, *view_z, *view_heading, *view_pitch;
 static float offset_x, offset_y, offset_z;
+static XPLMCommandRef track_toggle = NULL, translation_disable_toggle = NULL;
+static int track_disabled = 1;
+static int translation_disabled;
 
 static void reinit_offset() {
     offset_x = XPLMGetDataf(view_x);
@@ -93,14 +97,43 @@ float write_head_position(
 {
     if (lck_posix != NULL && shm_posix != NULL) {
         PortableLockedShm_lock(lck_posix);
-        XPLMSetDataf(view_x, shm_posix->data[TX] * 1e-3 + offset_x);
-        XPLMSetDataf(view_y, shm_posix->data[TY] * 1e-3 + offset_y);
-        XPLMSetDataf(view_z, shm_posix->data[TZ] * 1e-3 + offset_z);
+        if (!translation_disabled)
+        {
+            XPLMSetDataf(view_x, shm_posix->data[TX] * 1e-3 + offset_x);
+            XPLMSetDataf(view_y, shm_posix->data[TY] * 1e-3 + offset_y);
+            XPLMSetDataf(view_z, shm_posix->data[TZ] * 1e-3 + offset_z);
+        }
         XPLMSetDataf(view_heading, shm_posix->data[Yaw] * 180 / 3.141592654);
         XPLMSetDataf(view_pitch, shm_posix->data[Pitch] * 180 / 3.141592654);
         PortableLockedShm_unlock(lck_posix);
     }
     return -1.0;
+}
+
+static int TrackToggleHandler( XPLMCommandRef inCommand,
+                               XPLMCommandPhase inPhase,
+                               void * inRefCon )
+{
+    if ( track_disabled )
+    {
+        //Enable
+        XPLMRegisterFlightLoopCallback(write_head_position, -1.0, NULL);
+    }
+    else
+    {
+        //Disable
+        XPLMUnregisterFlightLoopCallback(write_head_position, NULL);
+    }
+    track_disabled = !track_disabled;
+    return 0;
+}
+
+static int TranslationToggleHandler( XPLMCommandRef inCommand,
+                                     XPLMCommandPhase inPhase,
+                                     void * inRefCon )
+{
+    translation_disabled = !translation_disabled;
+    return 0;
 }
 
 PLUGIN_API int XPluginStart ( char * outName, char * outSignature, char * outDescription ) {
@@ -109,7 +142,22 @@ PLUGIN_API int XPluginStart ( char * outName, char * outSignature, char * outDes
     view_z = XPLMFindDataRef("sim/aircraft/view/acf_peZ");
     view_heading = XPLMFindDataRef("sim/graphics/view/pilots_head_psi");
     view_pitch = XPLMFindDataRef("sim/graphics/view/pilots_head_the");
-    if (view_x && view_y && view_z && view_heading && view_pitch) {
+
+    track_toggle = XPLMCreateCommand("opentrack/toggle", "Disable/Enable head tracking");
+    translation_disable_toggle = XPLMCreateCommand("opentrack/toggle_translation", "Disable/Enable input translation from opentrack");
+
+    XPLMRegisterCommandHandler( track_toggle,
+                                TrackToggleHandler,
+                                1,
+                                (void*)0);
+
+    XPLMRegisterCommandHandler( translation_disable_toggle,
+                                TranslationToggleHandler,
+                                1,
+                                (void*)0);
+
+
+    if (view_x && view_y && view_z && view_heading && view_pitch && track_toggle && translation_disable_toggle) {
         lck_posix = PortableLockedShm_init(WINE_SHM_NAME, WINE_MTX_NAME, sizeof(WineSHM));
         if (lck_posix->mem == (void*)-1) {
             fprintf(stderr, "opentrack failed to init SHM!\n");
@@ -137,10 +185,12 @@ PLUGIN_API void XPluginStop ( void ) {
 
 PLUGIN_API void XPluginEnable ( void ) {
     XPLMRegisterFlightLoopCallback(write_head_position, -1.0, NULL);
+    track_disabled = 0;
 }
 
 PLUGIN_API void XPluginDisable ( void ) {
     XPLMUnregisterFlightLoopCallback(write_head_position, NULL);
+    track_disabled = 1;
 }
 
 PLUGIN_API void XPluginReceiveMessage(


### PR DESCRIPTION
* Replaced `XPLMRegisterDrawCallback` with ` XPLMRegisterFlightLoopCallback`, so that when the user tries to change the view it does not render a single frame on the new view (it is still not possible to change the view while the plugin is running, at least on Xplane 10.35).
* Added a command (*opentrack/toggle*) to disable the plugin from inside the sim.
* Added a command (*opentrack/toggle_translation*) to disable only the traslational components, so that we can still move around if OT only provides the rotations.
* Reinitialize the translational offsets when we re-enable the plugin, so that we can disable the plugin, move around (a long distance), and then re-enable the plugin in the new position.
