### PR TITLE
Kalman filter

### DIFF
--- a/filter-kalman/CMakeLists.txt
+++ b/filter-kalman/CMakeLists.txt
@@ -1,8 +1,6 @@
-if(FALSE)
 find_package(OpenCV 3.0 QUIET)
 if(OpenCV_FOUND)
     opentrack_boilerplate(opentrack-filter-kalman)
     target_link_libraries(opentrack-filter-kalman ${OpenCV_LIBS})
     target_include_directories(opentrack-filter-kalman SYSTEM PUBLIC ${OpenCV_INCLUDE_DIRS})
-endif()
 endif()

--- a/filter-kalman/ftnoir_filter_kalman.h
+++ b/filter-kalman/ftnoir_filter_kalman.h
@@ -18,6 +18,7 @@
 #include <QWidget>
 #include "opentrack-compat/options.hpp"
 using namespace options;
+#include "opentrack-compat/timer.hpp"
 
 struct settings : opts {
     value<int> noise_stddev_slider;
@@ -39,7 +40,8 @@ public:
     static constexpr double accel_stddev = (accel*4/(dt_*dt_))/3.0;
     cv::KalmanFilter kalman;
     double last_input[6];
-    QElapsedTimer timer;
+    Timer timer;
+    bool first_run;
     settings s;
     int prev_slider_pos;
 };


### PR DESCRIPTION
Meanwhile I attempted to fix the Kalman filter.

It turned out to be an issue with the timer. Possibly, the return value was assumed to be of a different unit than it really is. 

Rather than fixing the use of the QT timer, I instead replaced it with your `Timer` class for consistency.

Tbh. I'm a bit disappointed by the praised Kalman filter. It reacts either extremely slowly or it overshoots and comes back close to the real position in a very jittery way. That makes me want to try to make the process noise dependent on the predicted movement speed ... 

Also pinging @dbaarda 