### PR TITLE
Update ftnoir_tracker_udp.cpp

### DIFF
--- a/tracker-udp/ftnoir_tracker_udp.cpp
+++ b/tracker-udp/ftnoir_tracker_udp.cpp
@@ -22,7 +22,7 @@ void FTNoIR_Tracker::run()
     QByteArray datagram;
     datagram.resize(sizeof(last_recv_pose));
 
-    should_quit = sock.bind(QHostAddress::Any, quint16(s.port), QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+    should_quit = !sock.bind(QHostAddress::Any, quint16(s.port), QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
 
     while (!should_quit)
     {


### PR DESCRIPTION
On success, bind() function returns true. So while(!should_quit) loop was always skipped.