### PR TITLE
PT: improving point extractor's precision

### DIFF
--- a/tracker-pt/FTNoIR_PT_Controls.ui
+++ b/tracker-pt/FTNoIR_PT_Controls.ui
@@ -406,6 +406,20 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Mean-Shift (exp.)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QCheckBox" name="mean_shift_enable_checkbox">
+            <property name="text">
+             <string>Enable, accuracy and noise reduction</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/tracker-pt/ftnoir_tracker_pt_dialog.cpp
+++ b/tracker-pt/ftnoir_tracker_pt_dialog.cpp
@@ -65,6 +65,7 @@ TrackerDialog_PT::TrackerDialog_PT()
     tie_setting(s.init_phase_timeout, ui.init_phase_timeout);
 
     tie_setting(s.auto_threshold, ui.auto_threshold);
+    tie_setting(s.mean_shift_filter_blobs, ui.mean_shift_enable_checkbox);
 
     connect( ui.tcalib_button,SIGNAL(toggled(bool)), this,SLOT(startstop_trans_calib(bool)) );
 

--- a/tracker-pt/ftnoir_tracker_pt_settings.h
+++ b/tracker-pt/ftnoir_tracker_pt_settings.h
@@ -54,6 +54,8 @@ struct settings_pt : opts
     value<int> init_phase_timeout;
     value<bool> auto_threshold;
 
+    value<bool> mean_shift_filter_blobs;
+
     settings_pt() :
         opts("tracker-pt"),
         camera_name(b, "camera-name", ""),
@@ -83,6 +85,7 @@ struct settings_pt : opts
         fov(b, "camera-fov", 56),
         dynamic_pose(b, "dynamic-pose-resolution", true),
         init_phase_timeout(b, "init-phase-timeout", 500),
-        auto_threshold(b, "automatic-threshold", false)
+        auto_threshold(b, "automatic-threshold", false),
+        mean_shift_filter_blobs(b, "mean-shift-filter_blobs", false)
     {}
 };

--- a/tracker-pt/point_extractor.cpp
+++ b/tracker-pt/point_extractor.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "point_extractor.h"
+#include "point_tracker.h"
 #include <QDebug>
 
 #ifdef DEBUG_EXTRACTION
@@ -18,6 +19,62 @@
 #include <cmath>
 #include <algorithm>
 #include <cinttypes>
+
+
+
+/*
+http://en.wikipedia.org/wiki/Mean-shift
+In this application the idea, is to eliminate any bias of the point estimate 
+which is introduced by the rather arbitrary thresholded area. One must recognize
+that the thresholded area can only move in one pixel increments since it is
+binary. Thus, its center of mass might make "jumps" as pixels are added/removed
+from the thresholded area.
+With mean-shift, a moving "window" or kernel is multiplied with the gray-scale
+image, and the COM is calculated of the result. This is iterated where the
+kernel center is set the previously computed COM. Thus, peaks in the image intensity
+distribution "pull" the kernel towards themselves. Eventually it stops moving, i.e.
+then the computed COM coincides with the kernel center. We hope that the 
+corresponding location is a good candidate for the extracted point.
+The idea similar to the window scaling suggested in  Berglund et al. "Fast, bias-free 
+algorithm for tracking single particles with variable size and shape." (2008).
+*/
+static cv::Vec2d MeanShiftIteration(const cv::Mat &frame_gray, const cv::Vec2d &current_center, double filter_width)
+{
+    // Most amazingling this function runs faster with doubles than with floats.
+    const double s = 1.0 / filter_width;
+
+    auto EvalFilter = [&current_center, s](int row, int col)
+    {
+        double dx = (col - current_center[0])*s;
+        double dy = (row - current_center[1])*s;
+        double f = std::max(0.0, 1.0 - dx*dx - dy*dy);
+        return f;
+    };
+
+    double m = 0;
+    cv::Vec2d com(0.0, 0.0);
+    for (int i = 0; i < frame_gray.rows; i++)
+    {
+        auto frame_ptr = (uint8_t *)frame_gray.ptr(i);
+        for (int j = 0; j < frame_gray.cols; j++)
+        {
+            double val = frame_ptr[j];
+            val = val * val; // taking the square wights brighter parts of the image stronger.
+            val *= EvalFilter(i, j);
+            m += val;
+            com[0] += j * val;
+            com[1] += i * val;
+        }
+    }
+    if (m > 0.1)
+    {
+        com *= 1.0 / m;
+        return com;
+    }
+    else
+        return current_center;
+}
+
 
 PointExtractor::PointExtractor()
 {
@@ -136,7 +193,7 @@ void PointExtractor::extract_points(cv::Mat& frame, std::vector<PointExtractor::
                 if (radius > region_size_max || radius < region_size_min)
                     continue;
                 const double norm = double(m00);
-                blob b(radius, cv::Vec2d(m10 / norm, m01 / norm), vals/sqrt(double(cnt)));
+                blob b(radius, cv::Vec2d(m10 / norm, m01 / norm), vals/sqrt(double(cnt)), rect);
                 blobs.push_back(b);
                 {
                     char buf[64];
@@ -155,6 +212,36 @@ void PointExtractor::extract_points(cv::Mat& frame, std::vector<PointExtractor::
 
     sort(blobs.begin(), blobs.end(), [](const blob& b1, const blob& b2) -> bool { return b2.brightness < b1.brightness; });
 
+    if (s.mean_shift_filter_blobs)
+    {
+        for (idx = 0; idx < std::min<decltype(idx)>(PointModel::N_POINTS, blobs.size()); ++idx)
+        {
+            blob &b = blobs[idx];
+            cv::Rect rect = b.rect;
+            rect.x -= rect.width / 2;
+            rect.y -= rect.height / 2;
+            rect.width *= 2;
+            rect.height *= 2;
+            rect &= cv::Rect(0, 0, W, H);  // crop at frame boundaries
+
+            cv::Mat frame_roi = frame_gray(rect);
+
+            const double kernel_radius = b.radius * 1.5;
+            cv::Vec2d pos(b.pos[0] - rect.x, b.pos[1] - rect.y); // position relative to ROI.
+
+            for (int iter = 0; iter < 10; ++iter)
+            {
+                cv::Vec2d com_new = MeanShiftIteration(frame_roi, pos, kernel_radius);
+                cv::Vec2d delta = com_new - b.pos;
+                pos = com_new;
+                if (delta.dot(delta) < 1.0e-2) break;
+            }
+
+            b.pos[0] = pos[0] + rect.x;
+            b.pos[1] = pos[1] + rect.y;
+        }
+        // End of mean shift code. At this point, blob positions are updated which hopefully less noisy less biased values.
+    }
     points.reserve(max_blobs);
     points.clear();
 

--- a/tracker-pt/point_extractor.h
+++ b/tracker-pt/point_extractor.h
@@ -40,7 +40,9 @@ private:
     {
         double radius, brightness;
         vec2 pos;
-        blob(double radius, const cv::Vec2d& pos, double brightness) : radius(radius), brightness(brightness), pos(pos)
+        cv::Rect rect;
+
+        blob(double radius, const cv::Vec2d& pos, double brightness, cv::Rect &rect) : radius(radius), brightness(brightness), pos(pos), rect(rect)
         {
             //qDebug() << "radius" << radius << "pos" << pos[0] << pos[1];
         }


### PR DESCRIPTION
I finally finished implementing additional mean-shift filtering of the tracked blob-centers.

More importantly, I'm now rather sure that it is actually good. See comparison video on dropbox https://www.dropbox.com/sh/38get6zoksw7bw4/AAAoHiGetDZn_KFHLbHLKV3Ra?dl=0

Moreover, I guess I went a little bit over board trying different methods to improve the tracker's precision. To this end I implemented some prototypes in python. It is probably not immediately useful. But if you want to toy around with things some day, I guess this might be a solid basis.
https://github.com/DaMichel/opentrack-prototyping/blob/master/pointextractor.py
