### PR TITLE
tracklogging: begone file selector gui

### DIFF
--- a/gui/options-dialog.cpp
+++ b/gui/options-dialog.cpp
@@ -75,7 +75,6 @@ OptionsDialog::OptionsDialog(std::function<void(bool)> pause_keybindings) :
     tie_setting(main.center_method, ui.center_method);
 
     tie_setting(main.tracklogging_enabled, ui.tracklogging_enabled);
-    tie_setting(main.tracklogging_filename, ui.tracklogging_filenameedit);
 
     struct tmp
     {
@@ -108,8 +107,6 @@ OptionsDialog::OptionsDialog(std::function<void(bool)> pause_keybindings) :
             connect(val.button, &QPushButton::clicked, this, [=]() -> void { bind_key(val.opt, val.label); });
         }
     }
-
-    connect(ui.tracklogging_fileselectbtn, SIGNAL(clicked()), this, SLOT(browse_datalogging_file()));
 }
 
 void OptionsDialog::bind_key(key_opts& kopts, QLabel* label)
@@ -172,26 +169,6 @@ void OptionsDialog::doCancel()
     emit closing();
 }
 
-void OptionsDialog::browse_datalogging_file()
-{
-    QString filename = ui.tracklogging_filenameedit->text();
-    if (filename.isEmpty())
-        filename = OPENTRACK_BASE_PATH;
-    /* Sometimes this function freezes the app before opening the dialog.
-       Might be related to https://forum.qt.io/topic/49209/qfiledialog-getopenfilename-hangs-in-windows-when-using-the-native-dialog/8
-       and be a known problem. Possible solution is to use the QFileDialog::DontUseNativeDialog flag.
-       Since the freeze is apparently random, I'm not sure it helped.
-    */
-    QString newfilename = QFileDialog::getSaveFileName(this, tr("Select Filename"), filename, tr("CSV File (*.csv)"), nullptr, QFileDialog::DontUseNativeDialog);
-    if (!newfilename.isEmpty())
-        ui.tracklogging_filenameedit->setText(newfilename);
-
-    // dialog likes to mess with current directory
-    QDir::setCurrent(OPENTRACK_BASE_PATH);
-}
-
 void OptionsDialog::update_widgets_states(bool tracker_is_running)
 {
-    ui.tracklogging_enabled->setEnabled(!tracker_is_running);
-    ui.tracklogging_fileselectbtn->setEnabled(!tracker_is_running);
 }

--- a/gui/options-dialog.hpp
+++ b/gui/options-dialog.hpp
@@ -24,5 +24,4 @@ private slots:
     void doOK();
     void doCancel();
     void bind_key(key_opts &kopts, QLabel* label);
-    void browse_datalogging_file();
 };

--- a/gui/options-dialog.ui
+++ b/gui/options-dialog.ui
@@ -33,7 +33,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -1237,7 +1237,7 @@ It won't work properly with translation compensation enabled.</string>
        <item>
         <widget class="QGroupBox" name="groupBox_10">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -1245,75 +1245,21 @@ It won't work properly with translation compensation enabled.</string>
          <property name="minimumSize">
           <size>
            <width>0</width>
-           <height>20</height>
+           <height>50</height>
           </size>
          </property>
          <property name="title">
-          <string>Data Logging</string>
+          <string>CSV Data Logging</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_211">
           <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
-           <widget class="QLabel" name="tracklogging_label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Record pose data in a csv file. WARNING: overwrites file contents without warning every time the tracker is started.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QCheckBox" name="tracklogging_enabled">
             <property name="text">
-             <string>Enable</string>
+             <string>Enable - You will be asked for a filename whenever the tracker starts</string>
             </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QFrame" name="frame">
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>1</number>
-             </property>
-             <item>
-              <widget class="QPushButton" name="tracklogging_fileselectbtn">
-               <property name="text">
-                <string>Select File ...</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="tracklogging_filenameedit">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
-               </property>
-               <property name="inputMask">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
            </widget>
           </item>
          </layout>
@@ -1436,7 +1382,6 @@ It won't work properly with translation compensation enabled.</string>
   <tabstop>src_z</tabstop>
   <tabstop>invert_z</tabstop>
   <tabstop>tracklogging_enabled</tabstop>
-  <tabstop>tracklogging_fileselectbtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/logic/work.hpp
+++ b/logic/work.hpp
@@ -39,5 +39,5 @@ struct OPENTRACK_LOGIC_EXPORT Work
     void reload_shortcuts();
 
 private:
-    static std::shared_ptr<TrackLogger> make_logger(const main_settings &s);
+    static std::shared_ptr<TrackLogger> make_logger(main_settings &s);
 };


### PR DESCRIPTION
I didn't like it, considering it is mostly intended as a developer aid.
With this patch, the enable button is still there, but the edit field and the button are gone.
The file select dialog will pop up when the tracker starts.
The code is simpler, too.