### PR TITLE
Fix small compilation issue

### DIFF
--- a/gui/main-window.cpp
+++ b/gui/main-window.cpp
@@ -394,7 +394,7 @@ void MainWindow::refresh_config_list(bool warn)
                     ui.iconcomboProfile->setCurrentText(current);
                 }
 
-                options::detail::bundler::refresh_all_bundles(true);
+                options::detail::bundler::refresh_all_bundles();
             }
         }
         else


### PR DESCRIPTION
Small inconsistency here, the prototype is now:
static void options::detail::bundler::refresh_all_bundles()
So I remove the argument. Compilation fixed.