### PR TITLE
fixed macos build

### DIFF
--- a/compat/nan.cpp
+++ b/compat/nan.cpp
@@ -19,6 +19,11 @@ int __cdecl my_fpclassify(double)__asm__("___fpclassify");
 #define my_isinf(x) (my_fpclassify(x) == FP_INFINITE)
 
 extern "C" OTR_COMPAT_EXPORT bool __attribute__ ((noinline)) nanp(double x)
+#elif defined __APPLE__
+#   include <math.h>
+#   define my_isnan(x) isnan(x)
+#   define my_isinf(x) isinf(x)
+extern "C" OTR_COMPAT_EXPORT bool __attribute__ ((noinline)) nanp(double x)
 #else
 int my_isnan(double)__asm__("isnan");
 int my_isinf(double)__asm__("isinf");

--- a/compat/timer.cpp
+++ b/compat/timer.cpp
@@ -109,7 +109,7 @@ mach_timebase_info_data_t Timer::otr_get_mach_frequency()
     return timebase_info;
 }
 
-double Timer::otr_clock_gettime(timespec* ts)
+void Timer::otr_clock_gettime(timespec* ts)
 {
     static const mach_timebase_info_data_t timebase_info = otr_get_mach_frequency();
     uint64_t state, nsec;

--- a/qxt-mini/qxtglobalshortcut_mac.cpp
+++ b/qxt-mini/qxtglobalshortcut_mac.cpp
@@ -80,7 +80,7 @@ quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key keys)
 {
     UTF16Char ch;
     // Constants found in NSEvent.h from AppKit.framework
-    switch (key)
+    switch (keys)
     {
     case Qt::Key_Return:
         return kVK_Return;
@@ -170,11 +170,11 @@ quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key keys)
         ;
     }
 
-    if (key == Qt::Key_Escape)	ch = 27;
-    else if (key == Qt::Key_Return) ch = 13;
-    else if (key == Qt::Key_Enter) ch = 3;
-    else if (key == Qt::Key_Tab) ch = 9;
-    else ch = key;
+    if (keys == Qt::Key_Escape)	ch = 27;
+    else if (keys == Qt::Key_Return) ch = 13;
+    else if (keys == Qt::Key_Enter) ch = 3;
+    else if (keys == Qt::Key_Tab) ch = 9;
+    else ch = keys;
 
     CFDataRef currentLayoutData;
     TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardInputSource();

--- a/spline/spline.cpp
+++ b/spline/spline.cpp
@@ -9,8 +9,10 @@
 #include "spline.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <cmath>
 #include <memory>
+#include <cinttypes>
 
 #include <QObject>
 #include <QMutexLocker>


### PR DESCRIPTION
My specs: 
`macOS 10.12.6 Sierra` `Apple LLVM version 8.1.0 (clang-802.0.42)` `Cmake 3.9.0` `Xcode 8.3.3`

When i try build on macos using Clang i got some errors.

First on `opentrack/compat/timer.cpp:112:15`
```
error: return type of out-of-line definition of 'Timer::otr_clock_gettime' differs from that in the declaration
double Timer::otr_clock_gettime(timespec* ts)
```
_fixed by changing return type as declarated_.

Then i got linker errors for libopentrack-compat 
```
Undefined symbols for architecture x86_64:
  "isinf", referenced from:
      _nanp in nan.cpp.o
  "isnan", referenced from:
      _nanp in nan.cpp.o
ld: symbol(s) not found for architecture x86_64
```
_fixed by using  `isnan(double)` and `isinf(double)` from `<math.h>`_. This fix only for APPLE target.

Next error `opentrack/qxt-mini/qxtglobalshortcut_mac.cpp:174:14`
```
error: invalid use of member 'key' in static member function
```
_fixed by changing `quint32 nativeKeycode(Qt::Key keycode)` and `quint32 nativeModifiers(Qt::KeyboardModifiers modifiers)` to non-static functions._

Next `opentrack/spline/spline.cpp:148:9`
```
error: call to 'abs' is ambiguous
```
_fixed by using `<cstdlib>` instead `<cmath>`._

After those fixes i was able to build all project. Also i tested build on MS Visual Studio and Linux with gcc to prevert regression.