### PR TITLE
fixed qt binaries location for linux

### DIFF
--- a/cmake/opentrack-boilerplate.cmake
+++ b/cmake/opentrack-boilerplate.cmake
@@ -110,12 +110,19 @@ endfunction()
 
 function(otr_i18n_for_target_directory n)
     set(k "opentrack-${n}")
+
+    if (LINUX)
+        set(LUPDATE_BIN "${Qt5_DIR}/../../../../bin/lupdate")
+    else()
+        set(LUPDATE_BIN "${Qt5_DIR}/../../../bin/lupdate")
+    endif()
+
     foreach(i ${opentrack_all-translations})
         set(t "${CMAKE_CURRENT_SOURCE_DIR}/lang/${i}.ts")
         if(NOT opentrack_disable-i18n-update)
             add_custom_command(OUTPUT "${t}"
                 COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_SOURCE_DIR}/lang"
-                COMMAND "${Qt5_DIR}/../../../bin/lupdate" -silent -recursive -no-obsolete -locations relative . -ts "${t}"
+                COMMAND ${LUPDATE_BIN} -silent -recursive -no-obsolete -locations relative . -ts "${t}"
                 WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                 DEPENDS ${${k}-cc} ${${k}-hh} ${${k}-ui} ${${k}-rc}
                 COMMENT "Running lupdate for ${n}/${i}")

--- a/cmake/opentrack-install.cmake
+++ b/cmake/opentrack-install.cmake
@@ -65,11 +65,17 @@ function(merge_translations)
             endif()
         endforeach()
 
+        if (LINUX)
+            set(LRELEASE_BIN "${Qt5_DIR}/../../../../bin/lrelease")
+        else()
+            set(LRELEASE_BIN "${Qt5_DIR}/../../../bin/lrelease")
+        endif()
+
         if(NOT ".${ts-files_}" STREQUAL ".")
             set(qm-output "${CMAKE_CURRENT_BINARY_DIR}/${i}.qm")
             list(APPEND all-qm-files "${qm-output}")
             add_custom_command(OUTPUT "${qm-output}"
-                COMMAND "${Qt5_DIR}/../../../bin/lrelease" -nounfinished -silent ${ts-files_} -qm "${qm-output}"
+                COMMAND ${LRELEASE_BIN} -nounfinished -silent ${ts-files_} -qm "${qm-output}"
                 DEPENDS ${ts-files}
                 COMMENT "Running lrelease for ${i}")
             set(lang-target "i18n-lang-${i}")


### PR DESCRIPTION
my specs `Linux Mint 18.2 Sonya` based on `Ubuntu 16.04 LTS` `Cmake 3.5.1` `gcc (Ubuntu 5.4.1-2ubuntu1~16.04) 5.4.1 20160904`
On my system i have only en and ru localizations. When build opentrack target `i18n` i got error for for **nl_NL** 
```
make[2]: /usr/lib/x86_64-linux-gnu/cmake/Qt5/../../../bin/lrelease: command not found
```
On linux Qt5 cmake files located on `/usr/lib/x86_64-linux-gnu/cmake/` and Qt binaries located on `/usr/bin/`. For generating locales for **nl_NL**  cmake need lrelease and lupdate binaries. I fixed binaries path for linux target on cmake files.

I build on Linux, macOS and Windows. Also i tested this commit with my previous PL https://github.com/opentrack/opentrack/pull/668 to prevert conflicts.
