### PR TITLE
 macosx/install-fail-tool: fixed install_name_tool targets path

### DIFF
--- a/macosx/install-fail-tool
+++ b/macosx/install-fail-tool
@@ -4,7 +4,7 @@ test -n "$1" || exit 1
 
 dir="$1"
 
-for i in "$dir"/* "$dir"/*/* "$dir"/*/*/*; do
+for i in "$dir"/*; do
         { test -x "$i" && test -f "$i"; } || continue
         case "$i" in
             *.dll|*.exe) continue ;;


### PR DESCRIPTION
`install_name_tool` works only with dylib and binary files. No need work with subdirectories on `install-fail-tool` script.