### PR TITLE
wiiyourself worst problems

### DIFF
--- a/tracker-wii/wiiyourself/wiimote.cpp
+++ b/tracker-wii/wiiyourself/wiimote.cpp
@@ -1773,50 +1773,54 @@ int wiimote::ParseReadAddress (BYTE* buff)
 				break;
 				}
 
-			#define IF_TYPE(id)	if(type == id) { \
-									/* sometimes it comes in more than once */ \
-									if(Internal.ExtensionType == wiimote_state::id)\
-										break; \
-									Internal.ExtensionType = wiimote_state::id;
+                        // sometimes we get idempotent ExtensionType events
+                        #define IF_TYPE(id, ...)                                        \
+                            if(type == id)                                              \
+                            {                                                           \
+                                if(Internal.ExtensionType == wiimote_state::id)         \
+                                    break;                                              \
+                                Internal.ExtensionType = wiimote_state::id;             \
+                                { __VA_ARGS__ }                                         \
+                            }
 
 			// MotionPlus: once it's activated & mapped to the standard ext. port
-			IF_TYPE(MOTION_PLUS)
+                        IF_TYPE(MOTION_PLUS,
 				TRACE(_T(".. Motion Plus!"));
 				// and start a query for the calibration data
 				ReadAddress(REGISTER_EXTENSION_CALIBRATION, 16);
 				bMotionPlusDetected = true;
-				}
-			else IF_TYPE(NUNCHUK)
+                        )
+                        else IF_TYPE(NUNCHUK,
 				TRACE(_T(".. Nunchuk!"));
 				bMotionPlusEnabled = false;
 				// and start a query for the calibration data
 				ReadAddress(REGISTER_EXTENSION_CALIBRATION, 16);
-				}
-			else IF_TYPE(CLASSIC)
+                        )
+                        else IF_TYPE(CLASSIC,
 				TRACE(_T(".. Classic Controller!"));
 				bMotionPlusEnabled = false;
 				// and start a query for the calibration data
 				ReadAddress(REGISTER_EXTENSION_CALIBRATION, 16);
-				}
-			else IF_TYPE(GH3_GHWT_GUITAR)
+                        )
+                        else IF_TYPE(GH3_GHWT_GUITAR,
 				// sometimes it comes in more than once?
 				TRACE(_T(".. GH3/GHWT Guitar Controller!"));
 				bMotionPlusEnabled = false;
 				// and start a query for the calibration data
 				ReadAddress(REGISTER_EXTENSION_CALIBRATION, 16);
-				}
-			else IF_TYPE(GHWT_DRUMS)
+                        )
+                        else IF_TYPE(GHWT_DRUMS,
 				TRACE(_T(".. GHWT Drums!"));
 				bMotionPlusEnabled = false;
 				// and start a query for the calibration data
 				ReadAddress(REGISTER_EXTENSION_CALIBRATION, 16);
-				}
-			else IF_TYPE(BALANCE_BOARD)
+                        )
+                        else IF_TYPE(BALANCE_BOARD,
 				TRACE(_T(".. Balance Board!"));
 				bMotionPlusEnabled = false;
 				// and start a query for the calibration data
 				ReadAddress(REGISTER_BALANCE_CALIBRATION, 24);
-				}
+                        )
 			else if(type == PARTIALLY_INSERTED) {
 				// sometimes it comes in more than once?
 				if(Internal.ExtensionType == wiimote_state::PARTIALLY_INSERTED)

--- a/tracker-wii/wiiyourself/wiimote.cpp
+++ b/tracker-wii/wiiyourself/wiimote.cpp
@@ -74,16 +74,16 @@ template<class T> inline T square(const T& val)  { return val*val; }
 
 // internals: auto-strip code from the macros if they weren't defined
 #ifndef TRACE
-# define TRACE
+# define TRACE(...) (void)0
 #endif
 #ifndef DEEP_TRACE
-# define DEEP_TRACE
+# define DEEP_TRACE(...) (void)0
 #endif
 #ifndef WARN
-# define WARN
+# define WARN(...) (void)0
 #endif
 // ------------------------------------------------------------------------------------
-static void _cdecl _TRACE (const TCHAR* fmt, ...)
+static void __cdecl _TRACE (const TCHAR* fmt, ...)
 	{
 	static TCHAR buffer[256];
 	if (!fmt) return;
@@ -2407,7 +2407,7 @@ bool wiimote::Load16bitMonoSampleWAV (const TCHAR* filepath, wiimote_sample &out
 	union {
 		WAVEFORMATEX		 x;
 		WAVEFORMATEXTENSIBLE xe;
-		} wf = {0};
+                } wf = {};
 
 	riff_chunkheader riff_chunkheader;
 	chunk_header	 chunk_header;

--- a/tracker-wii/wiiyourself/wiimote.cpp
+++ b/tracker-wii/wiiyourself/wiimote.cpp
@@ -1934,6 +1934,7 @@ int wiimote::ParseReadAddress (BYTE* buff)
 					}
 					break;
 				}
+                        // XXX missing break here? -sh
 			case 0x34:
 				{
 				if(Internal.ExtensionType == BALANCE_BOARD)


### PR DESCRIPTION
Hey,

The build emits a ton of warnings due to unbalanced parentheses in the original `IF_TYPE` definition. I used `__VA_ARGS__` to get around it. I also fixed some of the worst compile-time warnings.

I'd like to run `clang-format` on wiiyourself while preserving line authorship information. In the farther future, I'd like to add a wrapper similar to `std::shared_ptr` for `HANDLE` types, etc. so that they never leak with the user not needing to release them manually.

Please see if this set of changes broke anything. I have no wiimote to check.