### PR TITLE
Bool option bug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,3 @@
 *.cc text=auto eol=lf
 *.md text=auto eol=lf
 *.csv text=auto eol=lf
-* text=auto eol=lf

--- a/options/connector.cpp
+++ b/options/connector.cpp
@@ -24,6 +24,9 @@ bool connector::is_equal(const QString& name, const QVariant& val1, const QVaria
 {
     QMutexLocker l(get_mtx());
 
+    if(val1.isValid() != val2.isValid())
+        return false;
+
     auto it = connected_values.find(name);
 
     if (it != connected_values.cend() && !std::get<0>((*it).second).empty())


### PR DESCRIPTION
When starting with a fresh install or "create new empty config" the boolean parameters on point tracker weren't getting saved and would always return to their defaults.

I tracked it down to [this line](https://github.com/opentrack/opentrack/blob/unstable/options/bundle.cpp#L66) where the if condition was always coming up `false`. Turns out `old_value` was an invalid `QVariant`, `new_value` was a valid boolean `QVariant`, but the `connector::is_equal` function reported `true` for them.

There might be a better way to fix it, I'm open to suggestions / edits. Happy to release these changes under ISC of course.