### PR TITLE
Using standard _ITERATOR_DEBUG_LEVEL by default

### DIFF
--- a/cmake/msvc.cmake
+++ b/cmake/msvc.cmake
@@ -20,6 +20,7 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 #C4928 - illegal copy-initialization, more than one user-defined conversion has been implicitly applied
 set(warns-disable 4530 4577 4789 4244 4702 4530 4244 4127 4458 4456 4251 4100 4702 4457)
 
+add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
 add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
 add_definitions(-D_ENABLE_ATOMIC_ALIGNMENT_FIX)
 add_definitions(-D_SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING)

--- a/cmake/opentrack-platform.cmake
+++ b/cmake/opentrack-platform.cmake
@@ -124,7 +124,6 @@ if(MSVC)
     add_definitions(-D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=1)
     add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 
-    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
     add_definitions(-D_HAS_EXCEPTIONS=0)
 
     add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)


### PR DESCRIPTION
Thus making default MSVC build working with default OpenCV static library build.
Closes #920.