### PR TITLE
FreePIE Use packed struct with clang to receive datagram

### DIFF
--- a/tracker-freepie-udp/ftnoir_tracker_freepie-udp.cpp
+++ b/tracker-freepie-udp/ftnoir_tracker_freepie-udp.cpp
@@ -17,21 +17,21 @@ tracker_freepie::~tracker_freepie()
 }
 
 void tracker_freepie::run() {
-#ifdef __clang__
-    struct __attribute__((packed)) {
+#ifndef __clang__
+#pragma pack(push)
+struct
+#else
+struct __attribute__((packed))
+#endif
+{
         uint8_t pad1;
         uint8_t flags;
         float fl[12];
-    } data  {};
-#else
-    #pragma pack(push, 1)
-        struct {
-            uint8_t pad1;
-            uint8_t flags;
-            float fl[12];
-        } data {};
-    #pragma pack(pop)
+} data;
+#ifndef __clang__
+#pragma pack(pop)
 #endif
+
 
     enum F
     {

--- a/tracker-freepie-udp/ftnoir_tracker_freepie-udp.cpp
+++ b/tracker-freepie-udp/ftnoir_tracker_freepie-udp.cpp
@@ -17,13 +17,21 @@ tracker_freepie::~tracker_freepie()
 }
 
 void tracker_freepie::run() {
-#pragma pack(push, 1)
-    struct {
+#ifdef __clang__
+    struct __attribute__((packed)) {
         uint8_t pad1;
         uint8_t flags;
         float fl[12];
-    } data {};
-#pragma pack(pop)
+    } data  {};
+#else
+    #pragma pack(push, 1)
+        struct {
+            uint8_t pad1;
+            uint8_t flags;
+            float fl[12];
+        } data {};
+    #pragma pack(pop)
+#endif
 
     enum F
     {


### PR DESCRIPTION
I noticed that in clang the datagram packed was expected to be 52byte. However the structure that is actually going over the wire is 50 byte.

This MR makes sure that on clang we also use the packed data structure