### PR TITLE
EDTracker support added.

### DIFF
--- a/tracker-edtracker/CMakeLists.txt
+++ b/tracker-edtracker/CMakeLists.txt
@@ -1,0 +1,6 @@
+if(WIN32 AND Qt5SerialPort_FOUND)
+    otr_module(tracker-edtracker)
+    target_link_libraries(${self} opentrack-dinput ${Qt5SerialPort_LIBRARIES})
+    target_include_directories(${self} SYSTEM PUBLIC ${Qt5SerialPort_INCLUDE_DIRS})
+endif()
+

--- a/tracker-edtracker/edtracker.cpp
+++ b/tracker-edtracker/edtracker.cpp
@@ -1,0 +1,122 @@
+/* Copyright (c) 2013 Stanislaw Halik <sthalik@misaki.pl>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ */
+#include "edtracker.h"
+#include "api/plugin-api.hpp"
+#include "compat/math.hpp"
+#include <QMutexLocker>
+
+edtracker::edtracker()
+{
+    if (s.guid->isEmpty())
+    {
+        std::vector<win32_joy_ctx::joy_info> info = joy_ctx.get_joy_info();
+        if (!info.empty())
+        {
+            s.guid = info[0].guid;
+            s.b->save();
+        }
+    }
+    if (s.com_port_name->isEmpty())
+    {
+        for (const QSerialPortInfo& port_info : QSerialPortInfo::availablePorts()) {
+            s.com_port_name = port_info.portName();
+            s.b->save();
+            break;
+        }
+    }
+}
+
+edtracker::~edtracker() = default;
+
+void edtracker::data(double *data)
+{
+    int map[6] = {
+        s.joy_1 - 1,
+        s.joy_2 - 1,
+        s.joy_3 - 1,
+        s.joy_4 - 1,
+        s.joy_5 - 1,
+        s.joy_6 - 1,
+    };
+
+    bool map_abs[6] = {
+        s.joy_1_abs,
+        s.joy_2_abs,
+        s.joy_3_abs,
+        s.joy_4_abs,
+        s.joy_5_abs,
+        s.joy_6_abs,
+    };
+
+    const double limits[] = {
+        100,
+        100,
+        100,
+        180,
+        180,
+        180
+    };
+
+    const QString guid = s.guid;
+    int axes[8];
+    const bool ret = joy_ctx.poll_axis(guid, axes);
+
+    if (ret)
+    {
+        for (int i = 0; i < 6; i++)
+        {
+            int k = map[i] - 1;
+            if (k < 0 || k >= 8)
+                data[i] = 0;
+            else
+                data[i] = clamp(axes[k] * limits[i] / AXIS_MAX,
+                                -limits[i], limits[i]);
+            if (map_abs[i] == true)
+                data[i] = abs(data[i]);
+        }
+    }
+}
+
+void edtracker::reset()
+{
+    const QString com_port_name = s.com_port_name;
+    QSerialPort com_port;
+    com_port.setPortName(com_port_name);
+    if (com_port.open(QIODevice::ReadWrite)) {
+        com_port.setBaudRate(QSerialPort::Baud9600);
+        com_port.setDataBits(QSerialPort::Data8);
+        com_port.setParity(QSerialPort::NoParity);
+        com_port.setStopBits(QSerialPort::OneStop);
+        com_port.setFlowControl(QSerialPort::NoFlowControl);
+        com_port.clear(QSerialPort::AllDirections);
+        QByteArray cmd("R");
+        com_port.write(cmd);
+        com_port.waitForBytesWritten(1000);
+        com_port.close();
+    }
+}
+
+void edtracker::calibrate()
+{
+    const QString com_port_name = s.com_port_name;
+    QSerialPort com_port;
+    com_port.setPortName(com_port_name);
+    if (com_port.open(QIODevice::ReadWrite)) {
+        com_port.setBaudRate(QSerialPort::Baud9600);
+        com_port.setDataBits(QSerialPort::Data8);
+        com_port.setParity(QSerialPort::NoParity);
+        com_port.setStopBits(QSerialPort::OneStop);
+        com_port.setFlowControl(QSerialPort::NoFlowControl);
+        com_port.clear(QSerialPort::AllDirections);
+        QByteArray cmd("r");
+        com_port.write(cmd);
+        com_port.waitForBytesWritten(1000);
+        com_port.close();
+    }
+}
+
+OPENTRACK_DECLARE_TRACKER(edtracker, dialog_edtracker, edtrackerDll)

--- a/tracker-edtracker/edtracker.h
+++ b/tracker-edtracker/edtracker.h
@@ -1,0 +1,99 @@
+/* Copyright (c) 2013 Stanislaw Halik <sthalik@misaki.pl>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ */
+#pragma once
+#include "ui_edtracker_controls.h"
+#include <QComboBox>
+#include <QCheckBox>
+#include <QSpinBox>
+#include <QMessageBox>
+#include <QSettings>
+#include <QList>
+#include <QFrame>
+#include <QStringList>
+#include <QSerialPort>
+#include <QSerialPortInfo>
+
+#include <cmath>
+#include "api/plugin-api.hpp"
+
+#include "dinput/win32-joystick.hpp"
+#include "options/options.hpp"
+using namespace options;
+
+struct settings : opts {
+    value<QString> guid;
+    value<int> joy_1, joy_2, joy_3, joy_4, joy_5, joy_6;
+    value<bool> joy_1_abs, joy_2_abs, joy_3_abs, joy_4_abs, joy_5_abs, joy_6_abs;
+    value<QString> com_port_name;
+    settings() :
+        opts("tracker-edtracker"),
+        guid(b, "joy-guid", ""),
+        joy_1(b, "axis-map-1", 1),
+        joy_2(b, "axis-map-2", 2),
+        joy_3(b, "axis-map-3", 3),
+        joy_4(b, "axis-map-4", 4),
+        joy_5(b, "axis-map-5", 5),
+        joy_6(b, "axis-map-6", 6),
+        joy_1_abs(b, "axis-map-1-abs", false),
+        joy_2_abs(b, "axis-map-2-abs", false),
+        joy_3_abs(b, "axis-map-3-abs", false),
+        joy_4_abs(b, "axis-map-4-abs", false),
+        joy_5_abs(b, "axis-map-5-abs", false),
+        joy_6_abs(b, "axis-map-6-abs", false),
+        com_port_name(b, "com-port-name", "")
+    {}
+};
+
+class edtracker : public ITracker
+{
+public:
+    edtracker();
+    ~edtracker();
+    module_status start_tracker(QFrame*) { calibrate(); return status_ok(); }
+    bool center() { reset(); return true; }
+    void data(double *data);
+    settings s;
+    QString guid;
+    QString com_port_name;
+    static constexpr int AXIS_MAX = win32_joy_ctx::joy_axis_size;
+    win32_joy_ctx joy_ctx;
+    void reset();
+    void calibrate();
+};
+
+class dialog_edtracker: public ITrackerDialog
+{
+    Q_OBJECT
+public:
+    dialog_edtracker();
+    void register_tracker(ITracker *) {}
+    void unregister_tracker() {}
+    Ui::UIEDTrackerControls ui;
+    edtracker* tracker;
+    settings s;
+    struct joys {
+        QString name;
+        QString guid;
+    };
+    QList<joys> joys_;
+    struct ports {
+        QString port;
+        QString serial;
+    };
+    QList<ports> ports_;
+private slots:
+    void doOK();
+    void doCancel();
+};
+
+class edtrackerDll : public Metadata
+{
+    Q_OBJECT
+
+    QString name() { return tr("EDTracker input"); }
+    QIcon icon() { return QIcon(":/images/opentrack.png"); }
+};

--- a/tracker-edtracker/edtracker_controls.ui
+++ b/tracker-edtracker/edtracker_controls.ui
@@ -1,0 +1,615 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+    <class>UIEDTrackerControls</class>
+    <widget class="QWidget" name="UIEDTrackerControls">
+        <property name="windowModality">
+            <enum>Qt::NonModal</enum>
+        </property>
+        <property name="geometry">
+            <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>498</width>
+                <height>303</height>
+            </rect>
+        </property>
+        <property name="windowTitle">
+            <string>EDTracker settings</string>
+        </property>
+        <property name="windowIcon">
+            <iconset>
+                <normaloff>../gui/images/opentrack.png</normaloff>../gui/images/opentrack.png
+            </iconset>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+            <property name="leftMargin">
+                <number>12</number>
+            </property>
+            <property name="topMargin">
+                <number>6</number>
+            </property>
+            <property name="rightMargin">
+                <number>12</number>
+            </property>
+            <property name="bottomMargin">
+                <number>6</number>
+            </property>
+            <item>
+                <widget class="QFrame" name="frame">
+                    <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                        </sizepolicy>
+                    </property>
+                    <property name="frameShape">
+                        <enum>QFrame::NoFrame</enum>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout">
+                        <item>
+                            <widget class="QLabel" name="label">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="text">
+                                    <string>Device</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item>
+                            <widget class="QComboBox" name="joylist">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                            </widget>
+                        </item>
+                        <item>
+                            <widget class="QLabel" name="label">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="text">
+                                    <string>Port  </string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item>
+                            <widget class="QComboBox" name="portlist">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                            </widget>
+                        </item>
+                    </layout>
+                </widget>
+            </item>
+            <item>
+                <widget class="QGroupBox" name="groupBox">
+                    <property name="title">
+                        <string>Mapping</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout">
+                        <item row="0" column="0">
+                            <widget class="QLabel" name="label">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="text">
+                                    <string>Data</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="1" column="0">
+                            <widget class="QLabel" name="label_5">
+                                <property name="text">
+                                    <string>X</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="2" column="0">
+                            <widget class="QLabel" name="label_6">
+                                <property name="text">
+                                    <string>Y</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="3" column="0">
+                            <widget class="QLabel" name="label_7">
+                                <property name="text">
+                                    <string>Z</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="4" column="0">
+                            <widget class="QLabel" name="label_2">
+                                <property name="text">
+                                    <string>Yaw</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="5" column="0">
+                            <widget class="QLabel" name="label_3">
+                                <property name="text">
+                                    <string>Pitch</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="6" column="0">
+                            <widget class="QLabel" name="label_4">
+                                <property name="text">
+                                    <string>Roll</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="0" column="1">
+                            <widget class="QLabel" name="label">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="text">
+                                    <string>Joy Axis</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="1" column="1">
+                            <widget class="QComboBox" name="joy_1">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="currentIndex">
+                                    <number>1</number>
+                                </property>
+                                <item>
+                                    <property name="text">
+                                        <string>Disabled</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #1</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #2</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #3</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #4</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #5</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #6</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #7</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #8</string>
+                                    </property>
+                                </item>
+                            </widget>
+                        </item>
+                        <item row="2" column="1">
+                            <widget class="QComboBox" name="joy_2">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="currentIndex">
+                                    <number>2</number>
+                                </property>
+                                <item>
+                                    <property name="text">
+                                        <string>Disabled</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #1</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #2</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #3</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #4</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #5</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #6</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #7</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #8</string>
+                                    </property>
+                                </item>
+                            </widget>
+                        </item>
+                        <item row="3" column="1">
+                            <widget class="QComboBox" name="joy_3">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="currentIndex">
+                                    <number>3</number>
+                                </property>
+                                <item>
+                                    <property name="text">
+                                        <string>Disabled</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #1</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #2</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #3</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #4</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #5</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #6</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #7</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #8</string>
+                                    </property>
+                                </item>
+                            </widget>
+                        </item>
+                        <item row="4" column="1">
+                            <widget class="QComboBox" name="joy_4">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="currentIndex">
+                                    <number>4</number>
+                                </property>
+                                <item>
+                                    <property name="text">
+                                        <string>Disabled</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #1</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #2</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #3</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #4</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #5</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #6</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #7</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #8</string>
+                                    </property>
+                                </item>
+                            </widget>
+                        </item>
+                        <item row="5" column="1">
+                            <widget class="QComboBox" name="joy_5">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="currentIndex">
+                                    <number>5</number>
+                                </property>
+                                <item>
+                                    <property name="text">
+                                        <string>Disabled</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #1</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #2</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #3</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #4</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #5</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #6</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #7</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #8</string>
+                                    </property>
+                                </item>
+                            </widget>
+                        </item>
+                        <item row="6" column="1">
+                            <widget class="QComboBox" name="joy_6">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="currentIndex">
+                                    <number>6</number>
+                                </property>
+                                <item>
+                                    <property name="text">
+                                        <string>Disabled</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #1</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #2</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #3</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #4</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #5</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #6</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #7</string>
+                                    </property>
+                                </item>
+                                <item>
+                                    <property name="text">
+                                        <string>EDTracker axis #8</string>
+                                    </property>
+                                </item>
+                            </widget>
+                        </item>
+                        <item row="0" column="2">
+                            <widget class="QLabel" name="label">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="text">
+                                    <string>Absolute</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="1" column="2">
+                            <widget class="QCheckBox" name="joy_1_abs">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="2" column="2">
+                            <widget class="QCheckBox" name="joy_2_abs">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="3" column="2">
+                            <widget class="QCheckBox" name="joy_3_abs">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="4" column="2">
+                            <widget class="QCheckBox" name="joy_4_abs">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="5" column="2">
+                            <widget class="QCheckBox" name="joy_5_abs">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="6" column="2">
+                            <widget class="QCheckBox" name="joy_6_abs">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                            </widget>
+                        </item>
+                    </layout>
+                </widget>
+            </item>
+            <item>
+                <widget class="QDialogButtonBox" name="buttonBox">
+                    <property name="standardButtons">
+                        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+                    </property>
+                </widget>
+            </item>
+        </layout>
+    </widget>
+    <tabstops>
+        <tabstop>buttonBox</tabstop>
+    </tabstops>
+    <resources/>
+    <connections/>
+    <slots>
+        <slot>startEngineClicked()</slot>
+        <slot>stopEngineClicked()</slot>
+        <slot>cameraSettingsClicked()</slot>
+    </slots>
+</ui>

--- a/tracker-edtracker/edtracker_dialog.cpp
+++ b/tracker-edtracker/edtracker_dialog.cpp
@@ -1,0 +1,87 @@
+#include "edtracker.h"
+#include "api/plugin-api.hpp"
+
+dialog_edtracker::dialog_edtracker() : tracker(nullptr)
+{
+    ui.setupUi( this );
+
+    // Connect Qt signals to member-functions
+    connect(ui.buttonBox, SIGNAL(accepted()), this, SLOT(doOK()));
+    connect(ui.buttonBox, SIGNAL(rejected()), this, SLOT(doCancel()));
+
+    {
+        win32_joy_ctx joy_ctx;
+
+        joys_ = {};
+
+        for (const auto& j : joy_ctx.get_joy_info())
+            joys_.push_back(joys { j.name, j.guid });
+    }
+
+    {
+        const QString guid = s.guid;
+        int idx = 0;
+        for (int i = 0; i < joys_.size(); i++)
+        {
+            const joys& j = joys_[i];
+            if (j.guid == guid)
+                idx = i;
+            ui.joylist->addItem(j.name + " " + j.guid);
+        }
+        ui.joylist->setCurrentIndex(idx);
+    }
+
+    {
+        ports_ = {};
+
+        for (const QSerialPortInfo& port_info : QSerialPortInfo::availablePorts()) {
+            ports_.push_back(ports { port_info.portName(), port_info.serialNumber() });
+        }
+    }
+
+    {
+        const QString com_port_name = s.com_port_name;
+        int pidx = 0;
+        for (int i = 0; i < ports_.size(); i++)
+        {
+            const ports& j = ports_[i];
+            if (j.port == com_port_name)
+                pidx = i;
+            ui.portlist->addItem(j.port);
+        }
+        ui.portlist->setCurrentIndex(pidx);
+    }
+
+    tie_setting(s.joy_1, ui.joy_1);
+    tie_setting(s.joy_2, ui.joy_2);
+    tie_setting(s.joy_3, ui.joy_3);
+    tie_setting(s.joy_4, ui.joy_4);
+    tie_setting(s.joy_5, ui.joy_5);
+    tie_setting(s.joy_6, ui.joy_6);
+
+    tie_setting(s.joy_1_abs, ui.joy_1_abs);
+    tie_setting(s.joy_2_abs, ui.joy_2_abs);
+    tie_setting(s.joy_3_abs, ui.joy_3_abs);
+    tie_setting(s.joy_4_abs, ui.joy_4_abs);
+    tie_setting(s.joy_5_abs, ui.joy_5_abs);
+    tie_setting(s.joy_6_abs, ui.joy_6_abs);
+}
+
+void dialog_edtracker::doOK() {
+    int idx = ui.joylist->currentIndex();
+    static const joys def { {}, {} };
+    auto val = joys_.value(idx, def);
+    s.guid = val.guid;
+
+    int pidx = ui.portlist->currentIndex();
+    static const ports pdef{ {}, {} };
+    auto pval = ports_.value(pidx, pdef);
+    s.com_port_name = pval.port;
+
+    s.b->save();
+    close();
+}
+
+void dialog_edtracker::doCancel() {
+    close();
+}

--- a/tracker-edtracker/lang/nl_NL.ts
+++ b/tracker-edtracker/lang/nl_NL.ts
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl_NL">
+<context>
+    <name>UIEDTrackerControls</name>
+    <message>
+        <source>Device</source>
+        <translation>Apparaat</translation>
+    </message>
+    <message>
+        <source>Mapping</source>
+        <translation>Verwijzing</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation>Uitgeschakeld</translation>
+    </message>
+    <message>
+        <source>EDTracker axis #1</source>
+        <translation>EDTracker-as #1</translation>
+    </message>
+    <message>
+        <source>EDTracker axis #2</source>
+        <translation>EDTracker-as #2</translation>
+    </message>
+    <message>
+        <source>EDTracker axis #3</source>
+        <translation>EDTracker-as #3</translation>
+    </message>
+    <message>
+        <source>EDTracker axis #4</source>
+        <translation>EDTracker-as #4</translation>
+    </message>
+    <message>
+        <source>EDTracker axis #5</source>
+        <translation>EDTracker-as #5</translation>
+    </message>
+    <message>
+        <source>EDTracker axis #6</source>
+        <translation>EDTracker-as #6</translation>
+    </message>
+    <message>
+        <source>EDTracker axis #7</source>
+        <translation>EDTracker-as #7</translation>
+    </message>
+    <message>
+        <source>EDTracker axis #8</source>
+        <translation>EDTracker-as #8</translation>
+    </message>
+    <message>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <source>Y</source>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <source>Z</source>
+        <translation>Z</translation>
+    </message>
+    <message>
+        <source>Yaw</source>
+        <translation>Yaw</translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <translation>Pitch</translation>
+    </message>
+    <message>
+        <source>Roll</source>
+        <translation>Rol</translation>
+    </message>
+    <message>
+        <source>EDTracker settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port  </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Joy Axis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Absolute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>edtrackerDll</name>
+    <message>
+        <source>EDTracker input</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/tracker-edtracker/lang/ru_RU.ts
+++ b/tracker-edtracker/lang/ru_RU.ts
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru_RU">
+<context>
+    <name>UIEDTrackerControls</name>
+    <message>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port  </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Joy Axis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Absolute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>edtrackerDll</name>
+    <message>
+        <source>EDTracker input</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/tracker-edtracker/lang/stub.ts
+++ b/tracker-edtracker/lang/stub.ts
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>UIEDTrackerControls</name>
+    <message>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port  </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Joy Axis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Absolute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>edtrackerDll</name>
+    <message>
+        <source>EDTracker input</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/tracker-edtracker/lang/zh_CN.ts
+++ b/tracker-edtracker/lang/zh_CN.ts
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>UIEDTrackerControls</name>
+    <message>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker axis #8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EDTracker settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port  </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Joy Axis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Absolute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>edtrackerDll</name>
+    <message>
+        <source>EDTracker input</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Based on Joystick tracker this module adds:
 * EDTracker calibration trigger on tracking start
 * EDTracker center trigger on Opentrack "center" tracker API event
 * Absolute axis mapping for pseudo 6dof (for example, roll left and right  can be mapped to always zoom-in left and right MFDs in DCS A10C)