### PR TITLE
proto/wine: add Proton 5.0 version number

### DIFF
--- a/proto-wine/ftnoir_protocol_wine_dialog.cpp
+++ b/proto-wine/ftnoir_protocol_wine_dialog.cpp
@@ -3,7 +3,7 @@
 #include "api/plugin-api.hpp"
 
 static const char* proton_versions[] = {
-    "4.11", "4.2", "3.16", "3.7",
+    "5.0", "4.11", "4.2", "3.16", "3.7",
 };
 
 FTControls::FTControls()


### PR DESCRIPTION
Proton 5.0 has been released recently. This extends the list of Proton version with the new version number.