### PR TITLE
Add proper color keying to tracker-pt

### DIFF
--- a/spline/spline-widget.cpp
+++ b/spline/spline-widget.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QPixmap>
 #include <QString>
 #include <QToolTip>

--- a/tracker-pt/FTNoIR_PT_Controls.ui
+++ b/tracker-pt/FTNoIR_PT_Controls.ui
@@ -422,32 +422,32 @@
             </item>
             <item>
              <property name="text">
-              <string>Red filter</string>
+              <string>Red chroma key</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Green filter</string>
+              <string>Green chroma key</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Blue filter</string>
+              <string>Blue chroma key</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Cyan filter</string>
+              <string>Cyan chroma key</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Yellow filter</string>
+              <string>Yellow chroma key</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Magenta filter</string>
+              <string>Magenta chroma key</string>
              </property>
             </item>
            </widget>

--- a/tracker-pt/FTNoIR_PT_Controls.ui
+++ b/tracker-pt/FTNoIR_PT_Controls.ui
@@ -420,6 +420,36 @@
               <string>Blue only</string>
              </property>
             </item>
+            <item>
+             <property name="text">
+              <string>Red filter</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Green filter</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Blue filter</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Cyan filter</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Yellow filter</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Magenta filter</string>
+             </property>
+            </item>
            </widget>
           </item>
           <item row="5" column="0">

--- a/tracker-pt/ftnoir_tracker_pt_dialog.cpp
+++ b/tracker-pt/ftnoir_tracker_pt_dialog.cpp
@@ -100,12 +100,12 @@ TrackerDialog_PT::TrackerDialog_PT(const QString& module_name) :
         pt_color_red_only,
         pt_color_green_only,
         pt_color_blue_only,
-        pt_color_red_filter,
-        pt_color_green_filter,
-        pt_color_blue_filter,
-        pt_color_cyan_filter,
-        pt_color_yellow_filter,
-        pt_color_magenta_filter,
+        pt_color_red_chromakey,
+        pt_color_green_chromakey,
+        pt_color_blue_chromakey,
+        pt_color_cyan_chromakey,
+        pt_color_yellow_chromakey,
+        pt_color_magenta_chromakey,
     };
 
     for (unsigned k = 0; k < std::size(color_types); k++)

--- a/tracker-pt/ftnoir_tracker_pt_dialog.cpp
+++ b/tracker-pt/ftnoir_tracker_pt_dialog.cpp
@@ -100,6 +100,12 @@ TrackerDialog_PT::TrackerDialog_PT(const QString& module_name) :
         pt_color_red_only,
         pt_color_green_only,
         pt_color_blue_only,
+        pt_color_red_filter,
+        pt_color_green_filter,
+        pt_color_blue_filter,
+        pt_color_cyan_filter,
+        pt_color_yellow_filter,
+        pt_color_magenta_filter,
     };
 
     for (unsigned k = 0; k < std::size(color_types); k++)

--- a/tracker-pt/lang/nl_NL.ts
+++ b/tracker-pt/lang/nl_NL.ts
@@ -232,6 +232,30 @@ Don&apos;t roll or change position.</source>
         <source>Green only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Red filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta filter</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/nl_NL.ts
+++ b/tracker-pt/lang/nl_NL.ts
@@ -233,27 +233,27 @@ Don&apos;t roll or change position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Red filter</source>
+        <source>Red chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Green filter</source>
+        <source>Green chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Blue filter</source>
+        <source>Blue chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cyan filter</source>
+        <source>Cyan chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Yellow filter</source>
+        <source>Yellow chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Magenta filter</source>
+        <source>Magenta chroma key</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/tracker-pt/lang/ru_RU.ts
+++ b/tracker-pt/lang/ru_RU.ts
@@ -238,27 +238,27 @@ ROLL или X/Y-смещения.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Red filter</source>
+        <source>Red chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Green filter</source>
+        <source>Green chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Blue filter</source>
+        <source>Blue chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cyan filter</source>
+        <source>Cyan chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Yellow filter</source>
+        <source>Yellow chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Magenta filter</source>
+        <source>Magenta chroma key</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/tracker-pt/lang/ru_RU.ts
+++ b/tracker-pt/lang/ru_RU.ts
@@ -237,6 +237,30 @@ ROLL или X/Y-смещения.</translation>
         <source>Green only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Red filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta filter</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/stub.ts
+++ b/tracker-pt/lang/stub.ts
@@ -232,6 +232,30 @@ Don&apos;t roll or change position.</source>
         <source>Green only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Red filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta filter</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/stub.ts
+++ b/tracker-pt/lang/stub.ts
@@ -233,27 +233,27 @@ Don&apos;t roll or change position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Red filter</source>
+        <source>Red chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Green filter</source>
+        <source>Green chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Blue filter</source>
+        <source>Blue chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cyan filter</source>
+        <source>Cyan chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Yellow filter</source>
+        <source>Yellow chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Magenta filter</source>
+        <source>Magenta chroma key</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/tracker-pt/lang/zh_CN.ts
+++ b/tracker-pt/lang/zh_CN.ts
@@ -232,6 +232,30 @@ Don&apos;t roll or change position.</source>
         <source>Green only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Red filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Green filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blue filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cyan filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yellow filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magenta filter</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/zh_CN.ts
+++ b/tracker-pt/lang/zh_CN.ts
@@ -233,27 +233,27 @@ Don&apos;t roll or change position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Red filter</source>
+        <source>Red chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Green filter</source>
+        <source>Green chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Blue filter</source>
+        <source>Blue chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cyan filter</source>
+        <source>Cyan chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Yellow filter</source>
+        <source>Yellow chroma key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Magenta filter</source>
+        <source>Magenta chroma key</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/tracker-pt/module/point_extractor.cpp
+++ b/tracker-pt/module/point_extractor.cpp
@@ -141,32 +141,32 @@ void PointExtractor::color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output)
         extract_single_channel(frame, 2, output);
         break;
     }
-    case pt_color_red_filter:
+    case pt_color_red_chromakey:
     {
         filter_single_channel(frame, 1, -0.5, -0.5, output);
         break;
     }
-    case pt_color_green_filter:
+    case pt_color_green_chromakey:
     {
         filter_single_channel(frame, -0.5, 1, -0.5, output);
         break;
     }
-    case pt_color_blue_filter:
+    case pt_color_blue_chromakey:
     {
         filter_single_channel(frame, -0.5, -0.5, 1, output);
         break;
     }
-    case pt_color_cyan_filter:
+    case pt_color_cyan_chromakey:
     {
         filter_single_channel(frame, -1, 0.5, 0.5, output);
         break;
     }
-    case pt_color_yellow_filter:
+    case pt_color_yellow_chromakey:
     {
         filter_single_channel(frame, 0.5, 0.5, -1, output);
         break;
     }
-    case pt_color_magenta_filter:
+    case pt_color_magenta_chromakey:
     {
         filter_single_channel(frame, 0.5, -1, 0.5, output);
         break;

--- a/tracker-pt/module/point_extractor.cpp
+++ b/tracker-pt/module/point_extractor.cpp
@@ -33,7 +33,7 @@ using namespace numeric_types;
 
 /*
 http://en.wikipedia.org/wiki/Mean-shift
-In this application the idea, is to eliminate any bias of the point estimate 
+In this application the idea, is to eliminate any bias of the point estimate
 which is introduced by the rather arbitrary thresholded area. One must recognize
 that the thresholded area can only move in one pixel increments since it is
 binary. Thus, its center of mass might make "jumps" as pixels are added/removed
@@ -42,9 +42,9 @@ With mean-shift, a moving "window" or kernel is multiplied with the gray-scale
 image, and the COM is calculated of the result. This is iterated where the
 kernel center is set the previously computed COM. Thus, peaks in the image intensity
 distribution "pull" the kernel towards themselves. Eventually it stops moving, i.e.
-then the computed COM coincides with the kernel center. We hope that the 
+then the computed COM coincides with the kernel center. We hope that the
 corresponding location is a good candidate for the extracted point.
-The idea similar to the window scaling suggested in  Berglund et al. "Fast, bias-free 
+The idea similar to the window scaling suggested in  Berglund et al. "Fast, bias-free
 algorithm for tracking single particles with variable size and shape." (2008).
 */
 static vec2 MeanShiftIteration(const cv::Mat1b &frame_gray, const vec2 &current_center, f filter_width)
@@ -115,6 +115,13 @@ void PointExtractor::extract_single_channel(const cv::Mat& orig_frame, int idx, 
     cv::mixChannels(&orig_frame, 1, &dest, 1, from_to, 1);
 }
 
+void PointExtractor::filter_single_channel(const cv::Mat& orig_frame, float r, float g, float b, cv::Mat1b& dest)
+{
+    ensure_channel_buffers(orig_frame);
+
+    cv::transform(orig_frame, dest, cv::Mat(cv::Matx13f(r, g, b)));
+}
+
 void PointExtractor::color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output)
 {
     switch (s.blob_color)
@@ -132,6 +139,36 @@ void PointExtractor::color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output)
     case pt_color_red_only:
     {
         extract_single_channel(frame, 2, output);
+        break;
+    }
+    case pt_color_red_filter:
+    {
+        filter_single_channel(frame, -0.5, -0.5, 1, output);
+        break;
+    }
+    case pt_color_green_filter:
+    {
+        filter_single_channel(frame, -0.5, 1, -0.5, output);
+        break;
+    }
+    case pt_color_blue_filter:
+    {
+        filter_single_channel(frame, 1, -0.5, -0.5, output);
+        break;
+    }
+    case pt_color_cyan_filter:
+    {
+        filter_single_channel(frame, 0.5, 0.5, -1, output);
+        break;
+    }
+    case pt_color_yellow_filter:
+    {
+        filter_single_channel(frame, -1, 0.5, 0.5, output);
+        break;
+    }
+    case pt_color_magenta_filter:
+    {
+        filter_single_channel(frame, 0.5, -1, 0.5, output);
         break;
     }
     case pt_color_average:

--- a/tracker-pt/module/point_extractor.cpp
+++ b/tracker-pt/module/point_extractor.cpp
@@ -119,7 +119,7 @@ void PointExtractor::filter_single_channel(const cv::Mat& orig_frame, float r, f
 {
     ensure_channel_buffers(orig_frame);
 
-    cv::transform(orig_frame, dest, cv::Mat(cv::Matx13f(r, g, b)));
+    cv::transform(orig_frame, dest, cv::Mat(cv::Matx13f(b, g, r)));
 }
 
 void PointExtractor::color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output)
@@ -143,7 +143,7 @@ void PointExtractor::color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output)
     }
     case pt_color_red_filter:
     {
-        filter_single_channel(frame, -0.5, -0.5, 1, output);
+        filter_single_channel(frame, 1, -0.5, -0.5, output);
         break;
     }
     case pt_color_green_filter:
@@ -153,17 +153,17 @@ void PointExtractor::color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output)
     }
     case pt_color_blue_filter:
     {
-        filter_single_channel(frame, 1, -0.5, -0.5, output);
+        filter_single_channel(frame, -0.5, -0.5, 1, output);
         break;
     }
     case pt_color_cyan_filter:
     {
-        filter_single_channel(frame, 0.5, 0.5, -1, output);
+        filter_single_channel(frame, -1, 0.5, 0.5, output);
         break;
     }
     case pt_color_yellow_filter:
     {
-        filter_single_channel(frame, -1, 0.5, 0.5, output);
+        filter_single_channel(frame, 0.5, 0.5, -1, output);
         break;
     }
     case pt_color_magenta_filter:

--- a/tracker-pt/module/point_extractor.h
+++ b/tracker-pt/module/point_extractor.h
@@ -49,6 +49,7 @@ private:
     void ensure_buffers(const cv::Mat& frame);
 
     void extract_single_channel(const cv::Mat& orig_frame, int idx, cv::Mat1b& dest);
+    void filter_single_channel(const cv::Mat& orig_frame, float r, float g, float b, cv::Mat1b& dest);
 
     void color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output);
     void threshold_image(const cv::Mat& frame_gray, cv::Mat1b& output);

--- a/tracker-pt/pt-settings.hpp
+++ b/tracker-pt/pt-settings.hpp
@@ -13,6 +13,12 @@ enum pt_color_type
     pt_color_average = 5,
     pt_color_blue_only = 6,
     pt_color_green_only = 7,
+    pt_color_red_filter = 8,
+    pt_color_green_filter = 9,
+    pt_color_blue_filter = 10,
+    pt_color_cyan_filter = 11,
+    pt_color_yellow_filter = 12,
+    pt_color_magenta_filter = 13,
 };
 
 namespace pt_impl {

--- a/tracker-pt/pt-settings.hpp
+++ b/tracker-pt/pt-settings.hpp
@@ -13,12 +13,12 @@ enum pt_color_type
     pt_color_average = 5,
     pt_color_blue_only = 6,
     pt_color_green_only = 7,
-    pt_color_red_filter = 8,
-    pt_color_green_filter = 9,
-    pt_color_blue_filter = 10,
-    pt_color_cyan_filter = 11,
-    pt_color_yellow_filter = 12,
-    pt_color_magenta_filter = 13,
+    pt_color_red_chromakey = 8,
+    pt_color_green_chromakey = 9,
+    pt_color_blue_chromakey = 10,
+    pt_color_cyan_chromakey = 11,
+    pt_color_yellow_chromakey = 12,
+    pt_color_magenta_chromakey = 13,
 };
 
 namespace pt_impl {


### PR DESCRIPTION
Instead of just selecting the red/green/blue channels, also subtract the
other channels. This allows for point tracking with just colored spots,
rather than IR LEDs -- green and magenta work particularly well for
this.

This keeps the existing "Red/Green/Blue only" options, but adds
"Red/Green/Blue/Cyan/Yellow/Magenta chroma key" options, which do a better
job of isolating those colors.

![Annotation 2020-06-05 103422](https://user-images.githubusercontent.com/46170/83906330-3779bc00-a718-11ea-9d26-6085fbed049b.png)
