### PR TITLE
Only set the wineprefix if not using proton

### DIFF
--- a/proto-wine/ftnoir_protocol_wine.cpp
+++ b/proto-wine/ftnoir_protocol_wine.cpp
@@ -80,7 +80,7 @@ module_status wine::initialize()
         if (!success)
             return error(error_string);
     }
-
+    else
     {
         QString wineprefix = "~/.wine";
         if (!s.wineprefix->isEmpty())


### PR DESCRIPTION
Sorry, seems this `else` was accidentally deleted in my last PR.  Without it the
wineprefix keeps getting set to ~/.wine
