### PR TITLE
Enable CMAKE_MSVC_RUNTIME_LIBRAY setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+# Enable MSVC runtime library setting 
+# (https://cmake.org/cmake/help/latest/prop_tgt/MSVC_RUNTIME_LIBRARY.html)
+cmake_policy(SET CMP0091 NEW) 
+
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
 set(CMAKE_C_LINKER_PREFERENCE_PROPAGATES OFF)
@@ -30,7 +35,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
 include(opentrack-policy NO_POLICY_SCOPE)
 
 project(opentrack)
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 # must be prior to CMakeDetermineCXXCompiler due to rpath
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR NOT CMAKE_INSTALL_PREFIX)


### PR DESCRIPTION
With this we can use
```
set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
```
in our configuration file. For example here is mine:

```
set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

# Debugging works without this.
set(opentrack_install-debug-info FALSE CACHE INTERNAL "" FORCE)

# QT from official web installer.
set(Qt5_DIR "D:/Dev/Qt5.12/5.15.2/msvc2019/lib/cmake/Qt5")
set(Qt5Core_DIR "${Qt5_DIR}Core" CACHE PATH "" FORCE)
set(Qt5Gui_DIR "${Qt5_DIR}Gui" CACHE PATH "" FORCE)

set(SDK_ONNX_LIBPATH "D:/dev/onnxruntime-x86-release/lib/onnxruntime.lib")
set(OpenCV_DIR "D:/Dev/opencv/buildx86/install/x86/vc15/staticlib")
```