### PR TITLE
Saner instructions for building ONNX Runtime for neuralnet tracker

### DIFF
--- a/tracker-neuralnet/BUILD.md
+++ b/tracker-neuralnet/BUILD.md
@@ -9,26 +9,12 @@ Source location: https://github.com/microsoft/onnxruntime
 In order to build, execute `build.bat` as follows:
 
 ```
-$ build.bat --config RelWithDebInfo --x86 --build_dir .\buildx86\ \
- --enable_msvc_static_runtime --build_shared_lib --skip_tests \
- --cmake_generator "Visual Studio 15 2017"
+$ build.bat --config Release --x86 --cmake_extra_defines CMAKE_INSTALL_PREFIX="D:\Dev\onnxruntime-x86-release" --build_dir .\buildx86\ --enable_msvc_static_runtime --build_shared_lib --skip_tests --cmake_generator "Visual Studio 15 2017"
+$ cmake --install .\buildx64\Release
 ```
 
-Replace the argument for `--cmake_generator` if needed.
+Replace the argument for `--cmake_generator` if needed. Also adjust the build-and install directories.
 
-The result is a messy directory `buildx86\RelWithDebInfo\RelWithDebInfo`,
-but no proper distribution. However only a few files are needed. They can
-be copied manually and are listed in the following in their respective folders:
+This should place all required files in the directory specified by CMAKE_INSTALL_PREFIX.
 
-```
-onnxruntime-x86-release/include:
-cpu_provider_factory.h                 onnxruntime_cxx_api.h
-experimental_onnxruntime_cxx_api.h     onnxruntime_cxx_inline.h
-experimental_onnxruntime_cxx_inline.h  onnxruntime_session_options_config_keys.h
-onnxruntime_c_api.h
-
-onnxruntime-x86-release/lib:
-onnxruntime.dll  onnxruntime.exp  onnxruntime.lib  onnxruntime.pdb
-```
-
-See also https://www.onnxruntime.ai/docs/how-to/build.html
+See also https://www.onnxruntime.ai/docs/how-to/build.html.


### PR DESCRIPTION
Looks like `cmake --install .\buildx64\Release` works after all.
It's not officially supported though, and it didn't work with `RelWithDebInfo`.
Still better than using NuGet?!