### PR TITLE
Adding a choice of centering method

### DIFF
--- a/gui/lang/nl_NL.ts
+++ b/gui/lang/nl_NL.ts
@@ -360,6 +360,22 @@ Press &quot;clear calibration&quot; to remove any calibration data pertaining to
         <source>None</source>
         <translation type="unfinished">Geen</translation>
     </message>
+    <message>
+        <source>Centering method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wireless VR 360</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Roll compensated VR 360</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>process_detector</name>

--- a/gui/lang/ru_RU.ts
+++ b/gui/lang/ru_RU.ts
@@ -363,6 +363,22 @@ Press &quot;clear calibration&quot; to remove any calibration data pertaining to
         <source>None</source>
         <translation>Не назначена</translation>
     </message>
+    <message>
+        <source>Centering method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wireless VR 360</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Roll compensated VR 360</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>process_detector</name>

--- a/gui/lang/stub.ts
+++ b/gui/lang/stub.ts
@@ -360,6 +360,22 @@ Press &quot;clear calibration&quot; to remove any calibration data pertaining to
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Centering method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wireless VR 360</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Roll compensated VR 360</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>process_detector</name>

--- a/gui/lang/zh_CN.ts
+++ b/gui/lang/zh_CN.ts
@@ -361,6 +361,22 @@ Press &quot;clear calibration&quot; to remove any calibration data pertaining to
         <source>None</source>
         <translation>空</translation>
     </message>
+    <message>
+        <source>Centering method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wireless VR 360</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Roll compensated VR 360</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>process_detector</name>

--- a/gui/settings-dialog.ui
+++ b/gui/settings-dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>548</width>
-    <height>599</height>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -812,19 +812,6 @@
           <enum>QFrame::Sunken</enum>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="center_at_startup">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Center at startup</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="0">
            <widget class="QCheckBox" name="disable_translation">
             <property name="sizePolicy">
@@ -838,6 +825,29 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Centering method</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="center_at_startup">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Center at startup</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="QLabel" name="label_29">
             <property name="text">
@@ -846,6 +856,39 @@
             <property name="pixmap">
              <pixmap resource="opentrack-res.qrc">:/images/english.png</pixmap>
             </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QComboBox" name="cbox_centering">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>4</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="currentIndex">
+             <number>3</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>Disabled</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Point</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Wireless VR 360</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Roll compensated VR 360</string>
+             </property>
+            </item>
            </widget>
           </item>
          </layout>
@@ -1569,8 +1612,14 @@
              </item>
              <item row="0" column="2">
               <widget class="QLabel" name="label_4">
+               <property name="layoutDirection">
+                <enum>Qt::LeftToRight</enum>
+               </property>
                <property name="text">
                 <string>X</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -1601,12 +1650,18 @@
                <property name="text">
                 <string>Pitch</string>
                </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
               </widget>
              </item>
              <item row="1" column="2">
               <widget class="QLabel" name="label_5">
                <property name="text">
                 <string>Y</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -1637,12 +1692,18 @@
                <property name="text">
                 <string>Z</string>
                </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
               </widget>
              </item>
              <item row="2" column="0">
               <widget class="QLabel" name="label_3">
                <property name="text">
                 <string>Roll</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -1672,6 +1733,9 @@
               <widget class="QLabel" name="label_2">
                <property name="text">
                 <string>Yaw</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -1807,6 +1871,9 @@
                  <horstretch>4</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
+               </property>
+               <property name="currentIndex">
+                <number>0</number>
                </property>
                <item>
                 <property name="text">

--- a/gui/settings.cpp
+++ b/gui/settings.cpp
@@ -59,6 +59,16 @@ options_dialog::options_dialog(std::function<void(bool)> pause_keybindings) :
 
     tie_setting(main.center_at_startup, ui.center_at_startup);
 
+    const centering_state centering_modes[] = {
+        center_disabled,
+        center_point,
+        center_vr360,
+        center_roll_compensated,
+    };
+    for (unsigned k = 0; k < 4; k++)
+        ui.cbox_centering->setItemData(k, int(centering_modes[k]));
+    tie_setting(main.centering_mode, ui.cbox_centering);
+
     const reltrans_state reltrans_modes[] = {
         reltrans_disabled,
         reltrans_enabled,

--- a/logic/main-settings.hpp
+++ b/logic/main-settings.hpp
@@ -22,6 +22,14 @@ enum reltrans_state
     reltrans_non_center = 2,
 };
 
+enum centering_state
+{
+    center_disabled         = 0,
+    center_point            = 1,
+    center_vr360            = 2,
+    center_roll_compensated = 3,
+};
+
 namespace main_settings_impl {
 
 using namespace options;
@@ -65,7 +73,7 @@ struct OTR_LOGIC_EXPORT main_settings final
     value<bool> tray_start { b, "start-in-tray", false };
 
     value<bool> center_at_startup { b, "center-at-startup", true };
-    //value<int> center_method;
+    value<centering_state> centering_mode { b, "centering-mode", center_roll_compensated };;
     value<int> neck_z { b, "neck-depth", 0 };
     value<bool> neck_enable { b, "neck-enable", false };
 

--- a/logic/pipeline.hpp
+++ b/logic/pipeline.hpp
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <cmath>
+#include <QQuaternion>
 
 #include "export.hpp"
 
@@ -99,8 +100,9 @@ class OTR_LOGIC_EXPORT pipeline : private QThread
     reltrans rel;
 
     struct {
-        rmat inv_R = rmat::eye();
-        Pose_ T;
+		Pose P;
+		QQuaternion QC = QQuaternion(1,0,0,0);
+		QQuaternion QR = QQuaternion(1,0,0,0);
     } center;
 
     time_units::ms backlog_time {};
@@ -111,8 +113,8 @@ class OTR_LOGIC_EXPORT pipeline : private QThread
     void logic();
     void run() override;
     bool maybe_enable_center_on_tracking_started();
-    void maybe_set_center_pose(const Pose& value, bool own_center_logic);
-    Pose apply_center(Pose value) const;
+    void maybe_set_center_pose(const centering_state mode, const Pose& value, bool own_center_logic);
+    Pose apply_center(const centering_state mode, Pose value) const;
     std::tuple<Pose, Pose, vec6_bool> get_selected_axis_values(const Pose& newpose) const;
     Pose maybe_apply_filter(const Pose& value) const;
     Pose apply_reltrans(Pose value, vec6_bool disabled, bool centerp);


### PR DESCRIPTION
Opentrack now uses several centering methods.
Select the centering method from the drop-down list: `[Options] - [Shortcuts] - "Centering method"`.

- **Disabled**: Centering is disabled.
- **Point**: Point centering, the same as in OT-2.3.10, but without jumps when crossing the border +/- 180 degrees. Well suited for video trackers, although near the input |Pitch| = 90 it has strange behavior similar to "gimbal lock".
- **Wireless VR 360**: Centering using a centering matrix or quaternion, the same as in OT-2.3.11...OT-2.3.13. Ideal for wireless VR headset for 360 degree viewing, no "gimbal lock". But it requires precise installation of the sensor or clip on the head so that in the central position the Roll angle on the "Raw tracker data" panel is close to zero.
- **Roll compensated VR 360**: It is a development of the previous version. It does not require precise installation of the sensor on the head. The sensor or clip can be tilted along the Roll, even at a 45 degree angle. Unlike the first option, there is no "gimbal lock". This centering option is suitable in most cases, especially for owners of an IMU tracker and laptop, when the screen is installed below (or above) eye level.

Do not forget to click `[OK]` to save the centering method selection to the profile file.

Hint: Now it is possible to reset the centering without stopping the tracking. To do this, while tracking, switch to `[Disabled]`, then press `[Center]`. This will reset the centering for all centering options.