### PR TITLE
Tracker neuralnet update onnxrt cmake (linux)

### DIFF
--- a/cmake/FindONNXRuntime.cmake
+++ b/cmake/FindONNXRuntime.cmake
@@ -1,0 +1,31 @@
+# FindONNXRuntime
+# ===============
+#
+# Find an ONNX Runtime installation.
+# ONNX Runtime is a cross-platform inference and training machine-learning
+# accelerator.
+#
+# Input variables
+# ---------------
+# 
+#   ONNXRuntime_ROOT            Set root installation.
+#
+# Output variable
+# ---------------
+# 
+#   ONNXRuntime_FOUND           Variable indicating that ONNXRuntime has been
+#                               found.
+#   ONNXRuntime_LIBRARIES       Library implementing ONNXRuntime
+#   ONNXRuntime_INCLUDE_DIRS    Headers for ONNXRuntime
+
+find_library(ORT_LIB onnxruntime
+    CMAKE_FIND_ROOT_PATH_BOTH)
+find_path(ORT_INCLUDE onnxruntime/core/session/onnxruntime_cxx_api.h
+    CMAKE_FIND_ROOT_PATH_BOTH)
+
+if(ORT_LIB AND ORT_INCLUDE)
+    set(ONNXRuntime_FOUND TRUE)
+    # For CMake output only
+    set(ONNXRuntime_LIBRARIES "${ORT_LIB}" CACHE STRING "ONNX Runtime libraries")
+    set(ONNXRuntime_INCLUDE_DIRS "${ORT_INCLUDE}" CACHE STRING "ONNX Runtime include path")
+endif()

--- a/cmake/FindONNXRuntime.cmake
+++ b/cmake/FindONNXRuntime.cmake
@@ -13,10 +13,9 @@
 # Output variable
 # ---------------
 # 
-#   ONNXRuntime_FOUND           Variable indicating that ONNXRuntime has been
-#                               found.
-#   ONNXRuntime_LIBRARIES       Library implementing ONNXRuntime
-#   ONNXRuntime_INCLUDE_DIRS    Headers for ONNXRuntime
+#   ONNXRuntime_FOUND           True if headers and requested libraries were found
+#   ONNXRuntime_LIBRARIES       Component libraries to be linked.
+#   ONNXRuntime_INCLUDE_DIRS    Include directories.
 
 find_library(ORT_LIB onnxruntime
     CMAKE_FIND_ROOT_PATH_BOTH)
@@ -25,7 +24,17 @@ find_path(ORT_INCLUDE onnxruntime/core/session/onnxruntime_cxx_api.h
 
 if(ORT_LIB AND ORT_INCLUDE)
     set(ONNXRuntime_FOUND TRUE)
-    # For CMake output only
-    set(ONNXRuntime_LIBRARIES "${ORT_LIB}" CACHE STRING "ONNX Runtime libraries")
-    set(ONNXRuntime_INCLUDE_DIRS "${ORT_INCLUDE}" CACHE STRING "ONNX Runtime include path")
+    set(ONNXRuntime_INCLUDE_DIRS "${ORT_INCLUDE}")
+
+    if(NOT TARGET onnxruntime)
+        add_library(onnxruntime UNKNOWN IMPORTED)
+        set_target_properties(onnxruntime PROPERTIES
+            IMPORTED_LOCATION "${ORT_LIB}"
+            INTERFACE_INCLUDE_DIRECTORIES "${ORT_INCLUDE}"
+            INTERFACE_LINK_LIBRARIES "onnxruntime")
+        list(APPEND ONNXRuntime_LIBRARIES onnxruntime)
+    endif()
 endif()
+
+unset(ORT_LIB CACHE)
+unset(ORT_INCLUDE CACHE)

--- a/cmake/FindONNXRuntime.cmake
+++ b/cmake/FindONNXRuntime.cmake
@@ -19,7 +19,9 @@
 
 find_library(ORT_LIB onnxruntime
     CMAKE_FIND_ROOT_PATH_BOTH)
-find_path(ORT_INCLUDE onnxruntime/core/session/onnxruntime_cxx_api.h
+
+find_path(ORT_INCLUDE onnxruntime_cxx_api.h
+    PATH_SUFFIXES onnxruntime/core/session
     CMAKE_FIND_ROOT_PATH_BOTH)
 
 if(ORT_LIB AND ORT_INCLUDE)

--- a/tracker-neuralnet/CMakeLists.txt
+++ b/tracker-neuralnet/CMakeLists.txt
@@ -1,18 +1,14 @@
 include(opentrack-opencv)
 find_package(OpenCV QUIET)
 find_package(OpenMP QUIET) # Used to control number of onnx threads.
-set(SDK_ONNX_LIBPATH "" CACHE FILEPATH "Full path of onnx library")
+find_package(ONNXRuntime REQUIRED)
 
-if(OpenCV_FOUND AND SDK_ONNX_LIBPATH AND OpenMP_FOUND)
-    get_filename_component(ONNX_INCLUDE_DIR "${SDK_ONNX_LIBPATH}" DIRECTORY)
-    get_filename_component(ONNX_INCLUDE_DIR "${ONNX_INCLUDE_DIR}" ABSOLUTE)
-    set(ONNX_INCLUDE_DIR "${ONNX_INCLUDE_DIR}/../include")
-
+if(OpenCV_FOUND AND ONNXRuntime_FOUND AND OpenMP_FOUND)
     otr_module(tracker-neuralnet)
     target_include_directories(${self} SYSTEM PUBLIC 
-        ${OpenCV_INCLUDE_DIRS} "${ONNX_INCLUDE_DIR}")
-    target_link_libraries(${self} 
-        opentrack-cv "${SDK_ONNX_LIBPATH}" opencv_imgproc opencv_core 
+        ${OpenCV_INCLUDE_DIRS} "${ONNXRuntime_INCLUDE_DIRS}")
+    target_link_libraries(${self} "${ONNXRuntime_LIBRARIES}"
+        opentrack-cv opencv_imgproc opencv_core
         opencv_imgcodecs opencv_calib3d
         OpenMP::OpenMP_C)
 

--- a/tracker-neuralnet/CMakeLists.txt
+++ b/tracker-neuralnet/CMakeLists.txt
@@ -1,19 +1,25 @@
 include(opentrack-opencv)
-find_package(OpenCV QUIET)
+find_package(OpenCV QUIET COMPONENTS imgproc core imgcodecs calib3d)
 find_package(OpenMP QUIET) # Used to control number of onnx threads.
 find_package(ONNXRuntime QUIET)
 
 if(OpenCV_FOUND AND ONNXRuntime_FOUND AND OpenMP_FOUND)
     otr_module(tracker-neuralnet)
-    target_include_directories(${self} SYSTEM PUBLIC 
-        ${OpenCV_INCLUDE_DIRS} "${ONNXRuntime_INCLUDE_DIRS}")
-    target_link_libraries(${self} "${ONNXRuntime_LIBRARIES}"
-        opentrack-cv opencv_imgproc opencv_core
-        opencv_imgcodecs opencv_calib3d
-        OpenMP::OpenMP_C)
-
+    target_include_directories(${self} 
+        SYSTEM PRIVATE 
+        ${OpenCV_INCLUDE_DIRS} 
+        ${ONNXRuntime_INCLUDE_DIRS}
+        )
+    target_link_libraries(${self} 
+        opentrack-cv 
+        ${ONNXRuntime_LIBRARIES} 
+        ${OpenCV_LIBS} 
+        OpenMP::OpenMP_C
+        )
     install(
-        FILES "models/head-localizer.onnx" "models/head-pose.onnx"
+        FILES "models/head-localizer.onnx" 
+              "models/head-pose.onnx"
         DESTINATION "${opentrack-libexec}/models"
-        PERMISSIONS ${opentrack-perms-file})
+        PERMISSIONS ${opentrack-perms-file}
+        )
 endif()

--- a/tracker-neuralnet/CMakeLists.txt
+++ b/tracker-neuralnet/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(opentrack-opencv)
 find_package(OpenCV QUIET)
 find_package(OpenMP QUIET) # Used to control number of onnx threads.
-find_package(ONNXRuntime REQUIRED)
+find_package(ONNXRuntime QUIET)
 
 if(OpenCV_FOUND AND ONNXRuntime_FOUND AND OpenMP_FOUND)
     otr_module(tracker-neuralnet)

--- a/tracker-neuralnet/CMakeLists.txt
+++ b/tracker-neuralnet/CMakeLists.txt
@@ -5,14 +5,9 @@ find_package(ONNXRuntime QUIET)
 
 if(OpenCV_FOUND AND ONNXRuntime_FOUND AND OpenMP_FOUND)
     otr_module(tracker-neuralnet)
-    target_include_directories(${self} 
-        SYSTEM PRIVATE 
-        ${OpenCV_INCLUDE_DIRS} 
-        ${ONNXRuntime_INCLUDE_DIRS}
-        )
     target_link_libraries(${self} 
-        opentrack-cv 
-        ${ONNXRuntime_LIBRARIES} 
+        opentrack-cv
+        onnxruntime
         ${OpenCV_LIBS} 
         OpenMP::OpenMP_C
         )

--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.h
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.h
@@ -26,7 +26,7 @@
 #include <memory>
 #include <cinttypes>
 
-#include <onnxruntime_cxx_api.h>
+#include <onnxruntime/core/session/onnxruntime_cxx_api.h>
 
 #include <opencv2/core.hpp>
 #include <opencv2/core/types.hpp>

--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.h
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.h
@@ -26,7 +26,7 @@
 #include <memory>
 #include <cinttypes>
 
-#include <onnxruntime/core/session/onnxruntime_cxx_api.h>
+#include <onnxruntime_cxx_api.h>
 
 #include <opencv2/core.hpp>
 #include <opencv2/core/types.hpp>


### PR DESCRIPTION
A proposal for minor changes to support system wide install though ONNXRuntime standard cmake module. (Tested on linux).
Set `ONNXRuntime_ROOT` for local build, i.e `cmake -DONNXRuntime_ROOT=/path/to/install`

NOTE: This PR provides a minimal working ONNXRuntime cmake module (request only `libonnxruntime.so`, no other components checked (providers, etc...). Official package may provide `ONNXRuntimeConfig.cmake` in the future.

See bellow to how to build and test the tracker with microsoft/ONNXRuntime (the cmake way)

## ONNXRuntime

### method1 - Build  from source (cmake)

```sh
# Version 1.8.1,  clang (->bug gcc) + system protobuf
git clone --single-branch --branch v1.8.1 git@github.com:microsoft/onnxruntime.git
cd onnxruntime
git submodule update --init --recursive
cmake -B workdir \
    -DCMAKE_BUILD_TYPE=Release 
    -DCMAKE_C_COMPILER=clang \
    -DCMAKE_CXX_COMPILER=clang++ \
    -DCMAKE_INSTALL_PREFIX=${HOME}/onnxruntime-linux-x64-1.8.1 \
    -Donnxruntime_ENABLE_PYTHON=OFF \
    -DONNX_CUSTOM_PROTOC_EXECUTABLE=/usr/bin/protoc \
    -Donnxruntime_PREFER_SYSTEM_LIB=ON \
    -Donnxruntime_USE_FULL_PROTOBUF=OFF \
    -Donnxruntime_BUILD_SHARED_LIB=ON \
    cmake
cmake --build workdir # -j4 (-jX X procs)
cmake --install workdir
# Tested on arch 
```

_Compilation may take some times_

### method2 - Use prebuild package

Get a [prebuild packages](https://github.com/microsoft/onnxruntime/releases) for your arch, for instance 

```sh
wget https://github.com/microsoft/onnxruntime/releases/download/v1.8.1/onnxruntime-linux-x64-1.8.1.tgz
tar -xzvf onnxruntime-linux-x64-1.8.1.tgz -C ${HOME}
```

## Build opentrack

To build opentrack with for a local ONNXRuntime install,

```sh
cmake -B work \
    -DCMAKE_BUILD_TYPE=Release \
    -DONNXRuntime_ROOT=${HOME}/onnxruntime-linux-x64-1.8.1 \
    -DSDK_WINE=ON \
    -DCMAKE_INSTALL_PREFIX=${HOME}/opentrack \
    .  
```

