### PR TITLE
cmake: improve the FindONNXRuntime script and install the ONNX dll

### DIFF
--- a/cmake/FindONNXRuntime.cmake
+++ b/cmake/FindONNXRuntime.cmake
@@ -8,7 +8,9 @@
 # Input variables
 # ---------------
 # 
-#   ONNXRuntime_ROOT            Set root installation.
+#   ONNXRuntime_ROOT            Set root installation. This is an environment
+#                               variable
+#   ONNXRuntime_DIR             CMake variable to set the installation root.
 #
 # Output variable
 # ---------------
@@ -17,26 +19,63 @@
 #   ONNXRuntime_LIBRARIES       Component libraries to be linked.
 #   ONNXRuntime_INCLUDE_DIRS    Include directories.
 
-find_library(ORT_LIB onnxruntime
+set(ONNXRuntime_DIR CACHE PATH "Root directory of the ONNX Runtime installation")
+
+# This script is mostly inspired by the guide there:
+# https://gitlab.kitware.com/cmake/community/-/wikis/doc/tutorials/How-To-Find-Libraries
+# Finding of the DLLs was added so we can install them with the application.
+# We adhere to modern CMake standards and also define an import library.
+
+find_library(ONNXRuntime_LIBRARY onnxruntime
+    HINTS
+        ${ONNXRuntime_DIR}
+    PATHS
+        ${CMAKE_INSTALL_PREFIX}
+    PATH_SUFFIXES lib lib64 bin
     CMAKE_FIND_ROOT_PATH_BOTH)
 
-find_path(ORT_INCLUDE onnxruntime_cxx_api.h
+if(WIN32)
+    SET(CMAKE_FIND_LIBRARY_SUFFIXES ".dll" ".DLL")
+    find_library(ONNXRuntime_RUNTIME onnxruntime
+        HINTS
+            ${ONNXRuntime_DIR}
+        PATHS
+            ${CMAKE_INSTALL_PREFIX}
+        PATH_SUFFIXES lib lib64 bin
+        CMAKE_FIND_ROOT_PATH_BOTH)
+else()
+    SET(ONNXRuntime_RUNTIME ${ONNXRuntime_LIBRARY})
+endif()
+
+find_path(ONNXRuntime_INCLUDE_DIR onnxruntime_cxx_api.h
+    HINTS
+        ${ONNXRuntime_DIR}/include
+        ${ONNXRuntime_DIR}
+    PATHS
+        ${CMAKE_INSTALL_PREFIX}/include
     PATH_SUFFIXES onnxruntime/core/session
     CMAKE_FIND_ROOT_PATH_BOTH)
 
-if(ORT_LIB AND ORT_INCLUDE)
-    set(ONNXRuntime_FOUND TRUE)
-    set(ONNXRuntime_INCLUDE_DIRS "${ORT_INCLUDE}")
 
-    if(NOT TARGET onnxruntime)
-        add_library(onnxruntime UNKNOWN IMPORTED)
-        set_target_properties(onnxruntime PROPERTIES
-            IMPORTED_LOCATION "${ORT_LIB}"
-            INTERFACE_INCLUDE_DIRECTORIES "${ORT_INCLUDE}"
-            INTERFACE_LINK_LIBRARIES "onnxruntime")
-        list(APPEND ONNXRuntime_LIBRARIES onnxruntime)
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set ONNXRuntime_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(ONNXRuntime  DEFAULT_MSG
+                                  ONNXRuntime_LIBRARY ONNXRuntime_INCLUDE_DIR ONNXRuntime_RUNTIME)
+
+if(ONNXRuntime_FOUND)
+    if(NOT TARGET onnxruntime::onnxruntime)
+        # Following this quide:
+        # https://cmake.org/cmake/help/git-stage/guide/importing-exporting/index.html#importing-libraries
+        add_library(onnxruntime::onnxruntime SHARED IMPORTED)
+        set_target_properties(onnxruntime::onnxruntime PROPERTIES
+            IMPORTED_LOCATION "${ONNXRuntime_RUNTIME}"
+            INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCLUDE_DIR}"
+            IMPORTED_IMPLIB "${ONNXRuntime_LIBRARY}")
     endif()
 endif()
 
-unset(ORT_LIB CACHE)
-unset(ORT_INCLUDE CACHE)
+mark_as_advanced(ONNXRuntime_INCLUDE_DIR ONNXRuntime_LIBRARY ONNXRuntime_RUNTIME)
+
+set(ONNXRuntime_INCLUDE_DIRS ${ONNXRuntime_INCLUDE_DIR})
+set(ONNXRuntime_LIBRARIES ${ONNXRuntime_LIBRARY})

--- a/tracker-neuralnet/CMakeLists.txt
+++ b/tracker-neuralnet/CMakeLists.txt
@@ -5,16 +5,20 @@ find_package(ONNXRuntime QUIET)
 
 if(OpenCV_FOUND AND ONNXRuntime_FOUND AND OpenMP_FOUND)
     otr_module(tracker-neuralnet)
+
     target_link_libraries(${self} 
         opentrack-cv
-        onnxruntime
+        onnxruntime::onnxruntime
         ${OpenCV_LIBS} 
         OpenMP::OpenMP_C
         )
+
     install(
         FILES "models/head-localizer.onnx" 
               "models/head-pose.onnx"
         DESTINATION "${opentrack-libexec}/models"
         PERMISSIONS ${opentrack-perms-file}
         )
+
+    otr_install_lib("${ONNXRuntime_RUNTIME}" ".")
 endif()


### PR DESCRIPTION
@sthalik , here is the promised follow-up PR. There were a few things that should be corrected. I didn't notice before. Now the find script feels like overkill. Otoh it also finds the DLL which is nice. And the import target is nice, too. Suppose it is the right approach for modern CMake.

Please review.

Have to check the latest iteration on windows.

Here is an overview of the changes

* Add ONNXRuntime_DIR variable
* Change target name to onnxruntime::onnxruntime following naming
  conventions for imported libs
* Look for the DLL on windows and store it in a variable for later
* Correctly define the properties of the import library
* Change names and logic for global variables to follow standard conventions

@gdolle FYI