### PR TITLE
Fix video capture on linux and mac as well as init of QCheckBox

### DIFF
--- a/pose-widget/pose-widget.hpp
+++ b/pose-widget/pose-widget.hpp
@@ -27,7 +27,7 @@ public:
     pose_widget(QWidget *parent = nullptr);
     void present(double xAngle, double yAngle, double zAngle, double x, double y, double z);
     QSize sizeHint() const override;
-    QCheckBox mirror{QCheckBox{"Mirror", this}};
+    QCheckBox mirror{"Mirror", this};
 private:
     void resizeEvent(QResizeEvent *event) override;
     void paintEvent(QPaintEvent*) override;

--- a/video-opencv/impl-camera.cpp
+++ b/video-opencv/impl-camera.cpp
@@ -33,7 +33,7 @@ bool cam::is_open()
 bool cam::start(info& args)
 {
     stop();
-    cap.emplace(idx, cv::CAP_DSHOW);
+    cap.emplace(idx, video_capture_backend);
 
     if (args.width > 0 && args.height > 0)
     {


### PR DESCRIPTION
Noticed that video capture was broken after updating the OpenCV version. This PR brings back the `video_capture_backend` variable which is still defined, but has been unused for a while it seems. Now it's working again for me.

The other thing with the initialization looks harmless. The extra copy was not needed though. And my compiler complained about it.