### PR TITLE
tracker/wii: allow repeated start()/stop() calls

### DIFF
--- a/tracker-wii/wii_camera.cpp
+++ b/tracker-wii/wii_camera.cpp
@@ -56,9 +56,7 @@ void WIICamera::show_camera_settings()
 
 WIICamera::result WIICamera::get_info() const
 {
-    if (cam_info.res_x == 0 || cam_info.res_y == 0)
-        return result(false, pt_camera_info());
-    return result(true, cam_info);
+    return {true, cam_info};
 }
 
 WIICamera::result WIICamera::get_frame(pt_frame& frame_)
@@ -88,22 +86,18 @@ WIICamera::result WIICamera::get_frame(pt_frame& frame_)
 
 bool WIICamera::start(const pt_settings&)
 {
+	if (m_pDev)
+		return true;
 	m_pDev = std::make_unique<wiimote>();
 	m_pDev->ChangedCallback = on_state_change;
 	m_pDev->CallbackTriggerFlags = (state_change_flags)(CONNECTED |
 		EXTENSION_CHANGED |
 		MOTIONPLUS_CHANGED);
-        return true;
+	return true;
 }
 
 void WIICamera::stop()
 {
-    desired_name = QString();
-    active_name = QString();
-    cam_info = pt_camera_info();
-    cam_desired = pt_camera_info();
-    onExit = true;
-
     if (m_pDev)
     {
         m_pDev->ChangedCallback = nullptr;
@@ -111,7 +105,7 @@ void WIICamera::stop()
         m_pDev = nullptr;
     }
 
-	Beep(1000, 200);
+    //Beep(1000, 200);
 }
 
 #ifdef __MINGW32__

--- a/tracker-wii/wii_camera.h
+++ b/tracker-wii/wii_camera.h
@@ -48,7 +48,6 @@ private:
 	static void on_state_change(wiimote &remote,
 		state_change_flags changed,
 		const wiimote_state &new_state);
-	bool onExit = false;
 
 	wii_camera_status pair();
 	wii_camera_status get_frame(cv::Mat& Frame);


### PR DESCRIPTION
Currently, the Wii camera doesn't support repeated calls to `start()` without intervening `stop()`, and calling `start()` after `stop()` has already been called.

I need this feature because of another WIP tracker (can't talk about it for now, sorry) that takes 2 seconds to start tracking at all, necessitating the `pt_api` change.

Please verify (at the beginning of `Tracker_PT::run()`) that the following works with the Wii tracker selected. I can't do it on my own, I don't have a Wii :(

```c++
auto camera = traits->make_camera();
qDebug() << "start1" << camera.start(s); // expecting true
auto [f1, inf1] = camera->get_frame(*frame);
qDebug() << "frame1" << f1; // expecting true
camera->stop();
camera->stop(); // twice on purpose
qDebug() << "start2" << camera.start(s); // expecting true
auto [f2, inf2] = camera->get_frame(*frame);
qDebug() << "frame2" << f2; // expecting true
camera = nullptr;
```

And @cpuwolf, sorry for the inconvenience.

-sh