### PR TITLE
tracker/nn: Remove onnx session options which hurt performance on Linux

### DIFF
--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
@@ -568,16 +568,12 @@ bool neuralnet_tracker::load_and_initialize_model()
         // before running the inference pass.
         opts.SetIntraOpNumThreads(num_threads);
         opts.SetInterOpNumThreads(num_threads);
-        opts.SetGraphOptimizationLevel(
-            GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
-
-        opts.EnableCpuMemArena();
         allocator_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
 
         localizer.emplace(
             allocator_info, 
             Ort::Session{env, convert(localizer_model_path_enc).c_str(), opts});
-        
+
         poseestimator.emplace(
             allocator_info,
             Ort::Session{env, convert(poseestimator_model_path_enc).c_str(), opts});


### PR DESCRIPTION
I don't get this ONNX framework ... the runtime for inference varies wildly:

Previously on Linux: 15 ms
With this patch: 10 ms
Windows with or without: 25 ms ...

Even using the latest official binaries.

I wrote a little spin-off speed test program. https://github.com/opentrack/neuralnet-tracker-traincode/tree/master/test/speed_test. Same results. I confirmed it's using only 1 core on Linux.

At least the speedup on Linux is nice. Maybe I'll eventually figure out what is wrong on Windows ...

P.S. @sthalik we don't have to build the runtime ourselves. I realized we can just go there: https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Managed/, download the nuget package and unpack it with our favorite zip tool. It contains the native dll as well as the c++ headers. Seems to work fine for me.