### PR TITLE
Adds a note regarding X-Plane plugin output (issue 1172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Don't be afraid to submit an **issue/feature request** if you have any problems!
 - Relaying UDP to another computer
 - Virtual joystick output (Windows, Linux, OSX)
 - Wine freetrack glue protocol (Linux, OSX)
-- X-Plane plugin (Linux)
+- X-Plane plugin (Linux; uses the Wine output option)
 - Tablet-like mouse output (Windows)
 - FlightGear
 - FSUIPC for Microsoft Flight Simulator 2002/2004 (Windows)


### PR DESCRIPTION
The readme states that Opentrack supports output to the X-Plane plugin. However, it is not documented anywhere that this is actually accomplished via the Wine output mode, leaving users [potentially confused](https://github.com/opentrack/opentrack/issues/1172) as to how to build Opentrack to enable an X-Plane output mode. I added a short note to this effect, which should steer would-be users in the right direction.

This resolves the above-mentioned issue 1172.