### PR TITLE
Fix initialization order issues in migration code

### DIFF
--- a/migration/migration.hpp
+++ b/migration/migration.hpp
@@ -43,6 +43,9 @@ namespace detail {
 
         static void set_last_migration_time(const QString& val);
         static int to_int(const QString& str, bool& ok);
+
+        static std::vector<mptr>& migration_list();
+        static std::vector<mfun>& migration_thunks();
     };
 
     template<typename t>


### PR DESCRIPTION
Hi,

I think there are some issues. There is this migration thingy ...
![grafik](https://user-images.githubusercontent.com/15868645/208759719-72b588a5-a542-464d-aaa7-cf47da70baa9.png)

It is initialized in the dynamic initialization phase and it accesses this `migration_thunks` vector you see me change in the PR.

The vector must be initialized, too, but to my knowledge this was not guaranteed to have happended. The order between different translation units would be up to the tooling. See https://en.cppreference.com/w/cpp/language/initialization, Sec Dynamic Initialization (3).

In my case, asserts in the windows debug CRT memory management functions were triggered. 

This patch seems to fix it. I replaced the global static vars with local static vars which would be initialized on first use. c++11 makes this thread safe, too. See https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables.

Cheers