### PR TITLE
Create profiles dir using proven method

### DIFF
--- a/cmake/opentrack-install.cmake
+++ b/cmake/opentrack-install.cmake
@@ -23,8 +23,7 @@ endfunction()
 
 otr_install_dir("${opentrack-doc}" ${CMAKE_SOURCE_DIR}/3rdparty-notices)
 otr_install_dir("${opentrack-doc}" "${CMAKE_SOURCE_DIR}/settings" "${CMAKE_SOURCE_DIR}/contrib")
-otr_escape_string(module-dir "${CMAKE_INSTALL_PREFIX}/${opentrack-libexec}")
-INSTALL(CODE "FILE(MAKE_DIRECTORY \"${module-dir}/presets\")")
+otr_install_dir("${opentrack-libexec}" ${CMAKE_SOURCE_DIR}/profiles)
 
 if(WIN32)
     otr_install_misc(. FILES "${CMAKE_SOURCE_DIR}/bin/qt.conf")


### PR DESCRIPTION
Attempting to directly create the profiles directory is causing problems when packaging for Arch Linux. This fix will copy the directory from the srcdir using already established install functions.

See https://aur.archlinux.org/packages/opentrack-git#comment-897814