### PR TITLE
x-plane-plugin update for X-Plane 12

### DIFF
--- a/x-plane-plugin/plugin.c
+++ b/x-plane-plugin/plugin.c
@@ -134,6 +134,8 @@ static int TrackToggleHandler(XPLMCommandRef inCommand,
                               XPLMCommandPhase inPhase,
                               void* inRefCon)
 {
+    if (inPhase != xplm_CommandBegin) return 0;
+
     if (track_disabled)
     {
         //Enable
@@ -156,6 +158,8 @@ static int TranslationToggleHandler(XPLMCommandRef inCommand,
                                     XPLMCommandPhase inPhase,
                                     void* inRefCon)
 {
+    if (inPhase != xplm_CommandBegin) return 0;
+    
     translation_disabled = !translation_disabled;
     if (!translation_disabled)
     {


### PR DESCRIPTION
In X-Plane 12, pressing a key bound for any of two x-plane-plugin toggles can result in significant unexpected camera base offset shift, which can be mildly annoying.

The cause of this is X-Plane generating a rapid stream of keypress events while the key is being held down, which together with current logic of keeping camera base offset when disabling head tracking results in this problem. 

An easy fix to this is only processing an initial key press and ignoring subsequent similar events until key is released. Such check is added in this pull request.

Tested in X-Plane 12 with plugin compiled against SDK 3.0.3 and SDK 4.0.0b1 on 64bit Linux. No other tests were performed. I invite @you to comment below if you can confirm that this fix works ok on any other platform or in XP11.