### PR TITLE
tracker/neuralnet: Add support for building on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(CMAKE_COMPILER_IS_GNUCXX AND NOT __otr_compile_flags_set)
     set(__otr_compile_flags_set TRUE CACHE INTERNAL "" FORCE)
     foreach(i C CXX)
         set(CMAKE_${i}_FLAGS_RELEASE "-O3 -march=native" CACHE STRING "" FORCE)
-        set(CMAKE_${i}_FLAGS "-ggdb -Wall -Wextra -Wpedantic -fopenmp" CACHE STRING "" FORCE)
+        set(CMAKE_${i}_FLAGS "-ggdb -Wall -Wextra -Wpedantic" CACHE STRING "" FORCE)
     endforeach()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(CMAKE_COMPILER_IS_GNUCXX AND NOT __otr_compile_flags_set)
     set(__otr_compile_flags_set TRUE CACHE INTERNAL "" FORCE)
     foreach(i C CXX)
         set(CMAKE_${i}_FLAGS_RELEASE "-O3 -march=native" CACHE STRING "" FORCE)
-        set(CMAKE_${i}_FLAGS "-ggdb -Wall -Wextra -Wpedantic" CACHE STRING "" FORCE)
+        set(CMAKE_${i}_FLAGS "-ggdb -Wall -Wextra -Wpedantic -fopenmp" CACHE STRING "" FORCE)
     endforeach()
 endif()
 

--- a/tracker-neuralnet/CMakeLists.txt
+++ b/tracker-neuralnet/CMakeLists.txt
@@ -1,5 +1,8 @@
 include(opentrack-opencv)
 set(host-spec "${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR} ${CMAKE_SIZEOF_VOID_P}")
+if(host-spec MATCHES "^Linux i[3-6]86 4$")
+    return()
+endif()
 
 find_package(OpenCV QUIET)
 find_package(OpenMP QUIET) # Used to control number of onnx threads.
@@ -13,15 +16,17 @@ if(OpenCV_FOUND AND ONNXRuntime_FOUND AND OpenMP_FOUND)
 
     otr_module(tracker-neuralnet)
 
-    target_link_libraries(${self} 
+    target_link_libraries(${self}
         opentrack-cv
         onnxruntime::onnxruntime
         opencv_calib3d
         opencv_imgproc
         opencv_imgcodecs
         opencv_core
-        OpenMP::OpenMP_C
+        OpenMP::OpenMP_CXX
         )
+    # OpenMP::OpenMP_CXX doesn't set up the -fopenmp linking option, so set it up ourselves.
+    target_link_options(${self} PUBLIC ${OpenMP_CXX_FLAGS})
 
     install(
         FILES "models/head-localizer.onnx" 

--- a/tracker-neuralnet/CMakeLists.txt
+++ b/tracker-neuralnet/CMakeLists.txt
@@ -1,8 +1,5 @@
 include(opentrack-opencv)
 set(host-spec "${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR} ${CMAKE_SIZEOF_VOID_P}")
-if(host-spec MATCHES "^Linux i[3-6]86 4$")
-    return()
-endif()
 
 find_package(OpenCV QUIET)
 find_package(OpenMP QUIET) # Used to control number of onnx threads.

--- a/tracker-neuralnet/model_adapters.cpp
+++ b/tracker-neuralnet/model_adapters.cpp
@@ -7,7 +7,7 @@
 #include <opencv2/imgproc.hpp>
 
 #include <QDebug>
-
+#include <algorithm>
 
 namespace neuralnet_tracker_ns
 {
@@ -165,6 +165,24 @@ double Localizer::last_inference_time_millis() const
 }
 
 
+std::string PoseEstimator::get_network_input_name(size_t i) const
+{
+#if ORT_API_VERSION >= 12
+    return std::string(&*session_.GetInputNameAllocated(i, allocator_));
+#else
+    return std::string(session_.GetInputName(i, allocator_));
+#endif
+}
+
+std::string PoseEstimator::get_network_output_name(size_t i) const
+{
+#if ORT_API_VERSION >= 12
+    return std::string(&*session_.GetOutputNameAllocated(i, allocator_));
+#else
+    return std::string(session_.GetOutputName(i, allocator_));
+#endif
+}
+
 PoseEstimator::PoseEstimator(Ort::MemoryInfo &allocator_info, Ort::Session &&session) 
     : model_version_{session.GetModelMetadata().GetVersion()}
     , session_{std::move(session)}
@@ -217,12 +235,12 @@ PoseEstimator::PoseEstimator(Ort::MemoryInfo &allocator_info, Ort::Session &&ses
     qDebug() << "Pose model outputs (" << session_.GetOutputCount() << "):";
     for (size_t i=0; i<session_.GetOutputCount(); ++i)
     {
-        const char* name = session_.GetOutputName(i, allocator_);
+        std::string name = get_network_output_name(i);
         const auto& output_info = session_.GetOutputTypeInfo(i);
         const auto& onnx_tensor_spec = output_info.GetTensorTypeAndShapeInfo();
         auto my_tensor_spec = understood_outputs.find(name);
 
-        qDebug() << "\t" << name << " (" << onnx_tensor_spec.GetShape() << ") dtype: " <<  onnx_tensor_spec.GetElementType() << " " <<
+        qDebug() << "\t" << name.c_str() << " (" << onnx_tensor_spec.GetShape() << ") dtype: " <<  onnx_tensor_spec.GetElementType() << " " <<
             (my_tensor_spec != understood_outputs.end() ? "ok" : "unknown");
 
         if (my_tensor_spec != understood_outputs.end())
@@ -272,7 +290,7 @@ PoseEstimator::PoseEstimator(Ort::MemoryInfo &allocator_info, Ort::Session &&ses
 
     for (size_t i = 0; i < session_.GetInputCount(); ++i)
     {
-        input_names_.push_back(session_.GetInputName(i, allocator_));
+        input_names_.push_back(get_network_input_name(i));
     }
 
     assert (input_names_.size() == input_val_.size());
@@ -310,13 +328,18 @@ std::optional<PoseEstimator::Face> PoseEstimator::run(
 
     try
     {
+        std::vector<const char *> input_names, output_names;
+        std::transform(input_names_.begin(), input_names_.end(), std::back_inserter(input_names),
+                       [&](const std::string &s){ return &s[0]; });
+        std::transform(output_names_.begin(), output_names_.end(), std::back_inserter(output_names),
+                       [&](const std::string &s){ return &s[0]; });
         session_.Run(
             Ort::RunOptions{ nullptr }, 
-            input_names_.data(), 
+            input_names.data(),
             input_val_.data(), 
             input_val_.size(), 
-            output_names_.data(), 
-            output_val_.data(), 
+            output_names.data(),
+            output_val_.data(),
             output_val_.size());
     }
     catch (const Ort::Exception &e)

--- a/tracker-neuralnet/model_adapters.h
+++ b/tracker-neuralnet/model_adapters.h
@@ -78,6 +78,7 @@ class PoseEstimator
         cv::Mat scaled_frame_{}, input_mat_{};  // Input. One is the original crop, the other is rescaled (?)
         std::vector<Ort::Value> input_val_;    // Tensors to put into the model
         std::vector<std::string> input_names_; // Refers to the names in the onnx model.
+        std::vector<const char *> input_c_names_; // Refers to the C names in the onnx model.
         // Outputs
         cv::Vec<float, 3> output_coord_{};  // 2d Coordinate and head size output.
         cv::Vec<float, 4> output_quat_{};   //  Quaternion output
@@ -87,6 +88,7 @@ class PoseEstimator
         cv::Vec<float, 3> output_coord_scales_{};
         std::vector<Ort::Value> output_val_; // Tensors to put the model outputs in.
         std::vector<std::string> output_names_; // Refers to the names in the onnx model.
+        std::vector<const char *> output_c_names_; // Refers to the C names in the onnx model.
         // More bookkeeping
         size_t num_recurrent_states_ = 0;
         double last_inference_time_ = 0;

--- a/tracker-neuralnet/model_adapters.h
+++ b/tracker-neuralnet/model_adapters.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <array>
 #include <vector>
+#include <string>
 
 #include <onnxruntime_cxx_api.h>
 #include <opencv2/core.hpp>
@@ -21,7 +22,7 @@ class Localizer
     public:
         Localizer(Ort::MemoryInfo &allocator_info,
                     Ort::Session &&session);
-        
+
         // Returns bounding wrt image coordinate of the input image
         // The preceeding float is the score for being a face normalized to [0,1].
         std::pair<float, cv::Rect2f> run(
@@ -68,13 +69,15 @@ class PoseEstimator
         bool has_uncertainty() const { return has_uncertainty_; }
 
     private:
+        std::string get_network_input_name(size_t i) const;
+        std::string get_network_output_name(size_t i) const;
         int64_t model_version_ = 0;  // Queried meta data from the ONNX file
         Ort::Session session_{nullptr};  // ONNX's runtime context for running the model
         Ort::Allocator allocator_;   // Memory allocator for tensors
         // Inputs
         cv::Mat scaled_frame_{}, input_mat_{};  // Input. One is the original crop, the other is rescaled (?)
         std::vector<Ort::Value> input_val_;    // Tensors to put into the model
-        std::vector<const char*> input_names_; // Refers to the names in the onnx model. 
+        std::vector<std::string> input_names_; // Refers to the names in the onnx model.
         // Outputs
         cv::Vec<float, 3> output_coord_{};  // 2d Coordinate and head size output.
         cv::Vec<float, 4> output_quat_{};   //  Quaternion output
@@ -83,7 +86,7 @@ class PoseEstimator
         cv::Vec<float, 2> output_eyes_{};
         cv::Vec<float, 3> output_coord_scales_{};
         std::vector<Ort::Value> output_val_; // Tensors to put the model outputs in.
-        std::vector<const char*> output_names_; // Refers to the names in the onnx model.
+        std::vector<std::string> output_names_; // Refers to the names in the onnx model.
         // More bookkeeping
         size_t num_recurrent_states_ = 0;
         double last_inference_time_ = 0;


### PR DESCRIPTION
* Remove tracker-neuralnet cmake code that prevents building on Linux.
* Update onnxruntime calling code for its API changes. onnxruntime has changed GetInputName/GetOutputName to GetInputNameAllocated/GetOutputNameAllocated in API version 12. Add compiling macro tests for that.

Fix issue #1559.