### PR TITLE
Bunch of tracking pipeline changes

### DIFF
--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
@@ -652,7 +652,7 @@ void NeuralNetTracker::data(double *data)
 
     const auto& mx = tmp.R.col(0);
     const auto& my = tmp.R.col(1);
-    const auto& mz = -tmp.R.col(2);
+    const auto& mz = tmp.R.col(2);
 
     const float yaw = std::atan2(mx(2), mx(0));
     const float pitch = -std::atan2(-mx(1), std::sqrt(mx(2)*mx(2)+mx(0)*mx(0)));

--- a/tracker-neuralnet/model_adapters.h
+++ b/tracker-neuralnet/model_adapters.h
@@ -73,7 +73,7 @@ class PoseEstimator
         std::string get_network_output_name(size_t i) const;
         int64_t model_version_ = 0;  // Queried meta data from the ONNX file
         Ort::Session session_{nullptr};  // ONNX's runtime context for running the model
-        Ort::Allocator allocator_;   // Memory allocator for tensors
+        mutable Ort::Allocator allocator_;   // Memory allocator for tensors
         // Inputs
         cv::Mat scaled_frame_{}, input_mat_{};  // Input. One is the original crop, the other is rescaled (?)
         std::vector<Ort::Value> input_val_;    // Tensors to put into the model


### PR DESCRIPTION
Hi @sthalik , @GO63-samara 

I would like to discuss a few changes. Commit by commit:

* Combine Accela with Hamilton filter: We can compute the delta as angle-axis pair like in your Hamilton filter @GO63-samara , and apply the gain function from Accela. The extra wide "zoom deadzone" could also be integrated easily. Didn't do that yet.
Hence I propose to combine both filters and take the best of both worlds. On that occassion I would also delete the Kalman filter (which I wrote) because it just isn't as good.

* Fix compile error: Not very interesting for you, I guess. It's just that the ORT API didn't like the constness of the allocator which it had because it was used from a const-function.

* Fix 180 deg roll: I noticed the neuralnet tracker outputs roll offset by +/- 180 deg. This shall be the fix.

* apply_zero_post first ...: My tentative attempt to fix the yaw-pitch coupling. So I moved this `apply_zero_post` forward in the processing chain and changed it to work like the VR 360 centering option. The idea being that we do a proper 3d coordinate change. So the head pose afterwards is measured wrt this new centered frame including the subsequently computed euler angles.
Should help with cameras mounted at an angle. Intended use is simple, the user attains a centered pose, notes the raw tracker output and fills these values into the zero-pose fields. As a side effect, opentrack starts roughly centered, due to the zero-pose persistence.
I tried to keep the function in the old place, but I didn't get the right results. I suppose it's because the mapping curves are applied beforehand. I don't understand it though tbh. Probably my change breaks a bunch of other options. Hence it's not meant as the ultimate solution. And I also realize that it's very redundant with the center function when VR 360 is used. @sthalik , I would like to understand what the other center modes are for. I think maybe we could remove some options except the VR 360 center mode. Any ideas?

* Try new model: A new neural net which, after (brief) testing, I like more than the original. It provides the uncertainty estimates which are needed for the extra filtering in the tracker itself. I observed the uncertainty estimates increase when eyes get closed actually. They drive the size of a deadzone. During testing I got a more stable view which was especially noticable when zooming in, trying to focus on targets. Maybe you can give it a try.