### PR TITLE
Improved chroma key for point tracker

### DIFF
--- a/tracker-pt/FTNoIR_PT_Controls.ui
+++ b/tracker-pt/FTNoIR_PT_Controls.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>413</width>
-    <height>628</height>
+    <height>630</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -486,6 +486,9 @@
             </item>
             <item>
              <widget class="QDoubleSpinBox" name="chroma_key_strength_label">
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
               <property name="readOnly">
                <bool>true</bool>
               </property>
@@ -733,7 +736,7 @@
           <enum>QTabWidget::Rounded</enum>
          </property>
          <property name="currentIndex">
-          <number>2</number>
+          <number>0</number>
          </property>
          <property name="usesScrollButtons">
           <bool>false</bool>
@@ -1767,10 +1770,11 @@ Don't roll or change position.</string>
   <tabstop>fps_spin</tabstop>
   <tabstop>use_mjpeg</tabstop>
   <tabstop>fov</tabstop>
-  <tabstop>init_phase_timeout</tabstop>
   <tabstop>dynamic_pose</tabstop>
+  <tabstop>init_phase_timeout</tabstop>
   <tabstop>camera_settings</tabstop>
   <tabstop>blob_color</tabstop>
+  <tabstop>chroma_key_strength_slider</tabstop>
   <tabstop>chroma_key_overexposed</tabstop>
   <tabstop>auto_threshold</tabstop>
   <tabstop>threshold_slider</tabstop>
@@ -1781,19 +1785,19 @@ Don't roll or change position.</string>
   <tabstop>clip_theight_spin</tabstop>
   <tabstop>clip_bheight_spin</tabstop>
   <tabstop>clip_blength_spin</tabstop>
-  <tabstop>tx_spin</tabstop>
-  <tabstop>ty_spin</tabstop>
-  <tabstop>tz_spin</tabstop>
-  <tabstop>tcalib_button</tabstop>
   <tabstop>cap_length_spin</tabstop>
   <tabstop>cap_width_spin</tabstop>
   <tabstop>cap_height_spin</tabstop>
   <tabstop>m1x_spin</tabstop>
-  <tabstop>m2x_spin</tabstop>
   <tabstop>m1y_spin</tabstop>
-  <tabstop>m2y_spin</tabstop>
   <tabstop>m1z_spin</tabstop>
+  <tabstop>m2x_spin</tabstop>
+  <tabstop>m2y_spin</tabstop>
   <tabstop>m2z_spin</tabstop>
+  <tabstop>tx_spin</tabstop>
+  <tabstop>ty_spin</tabstop>
+  <tabstop>tz_spin</tabstop>
+  <tabstop>tcalib_button</tabstop>
   <tabstop>enable_point_filter</tabstop>
   <tabstop>point_filter_slider</tabstop>
   <tabstop>point_filter_limit_slider</tabstop>

--- a/tracker-pt/FTNoIR_PT_Controls.ui
+++ b/tracker-pt/FTNoIR_PT_Controls.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>413</width>
-    <height>604</height>
+    <height>628</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -79,10 +79,100 @@
           <string>Camera settings</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
+          <item row="11" column="1">
+           <widget class="QCheckBox" name="chroma_key_overexposed">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="cursor">
+             <cursorShape>WhatsThisCursor</cursorShape>
+            </property>
+            <property name="toolTip">
+             <string>This should be 56° or 76° for the PS3 Eye, dependent upon the physical lens setting. It's only neccessary to get position correspond to real-world values.</string>
+            </property>
+            <property name="text">
+             <string>Diagonal field of view</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Dynamic pose (for caps only, never clips)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="cursor">
+             <cursorShape>WhatsThisCursor</cursorShape>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For LEDs, 'Natural' is the fastest grayscale mode thanks to optimized SIMD code. Color key allows to track regular pieces of colored paper.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Color channels used</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QPushButton" name="camera_settings">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Open</string>
+            </property>
+           </widget>
+          </item>
           <item row="4" column="1">
            <widget class="QCheckBox" name="use_mjpeg">
             <property name="text">
              <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_13">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="cursor">
+             <cursorShape>WhatsThisCursor</cursorShape>
+            </property>
+            <property name="toolTip">
+             <string>Enable MJPEG compression for high-speed cameras other than the PS3 Eye. Windows only.</string>
+            </property>
+            <property name="text">
+             <string>MJPEG compression</string>
             </property>
            </widget>
           </item>
@@ -99,6 +189,71 @@
             </property>
             <property name="buddy">
              <cstring>fps_spin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_36">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="0">
+           <widget class="QLabel" name="label_16">
+            <property name="text">
+             <string>Chroma key includes overexposed pixels</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Camera settings (when available)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QSpinBox" name="init_phase_timeout">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="suffix">
+             <string> ms</string>
+            </property>
+            <property name="minimum">
+             <number>50</number>
+            </property>
+            <property name="maximum">
+             <number>5000</number>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QCheckBox" name="dynamic_pose">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string/>
             </property>
            </widget>
           </item>
@@ -124,22 +279,58 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_4">
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_6">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="cursor">
-             <cursorShape>WhatsThisCursor</cursorShape>
+            <property name="text">
+             <string>Dynamic pose timeout</string>
             </property>
-            <property name="toolTip">
-             <string>This should be 56° or 76° for the PS3 Eye, dependent upon the physical lens setting. It's only neccessary to get position correspond to real-world values.</string>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="camdevice_combo">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumContentsLength">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
             <property name="text">
-             <string>Diagonal field of view</string>
+             <string>Device</string>
+            </property>
+            <property name="buddy">
+             <cstring>camdevice_combo</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_41">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Height</string>
             </property>
            </widget>
           </item>
@@ -159,99 +350,6 @@
             </property>
             <property name="maximum">
              <number>2000</number>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QCheckBox" name="dynamic_pose">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1">
-           <widget class="QPushButton" name="camera_settings">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Open</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_41">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Height</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="camdevice_combo">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumContentsLength">
-             <number>10</number>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
-           <widget class="QSpinBox" name="init_phase_timeout">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="suffix">
-             <string> ms</string>
-            </property>
-            <property name="minimum">
-             <number>50</number>
-            </property>
-            <property name="maximum">
-             <number>5000</number>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QSpinBox" name="fov">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="suffix">
-             <string>°</string>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="minimum">
-             <number>10</number>
-            </property>
-            <property name="maximum">
-             <number>90</number>
             </property>
            </widget>
           </item>
@@ -320,29 +418,25 @@
             </item>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_36">
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="fov">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="text">
-             <string>Width</string>
+            <property name="suffix">
+             <string>°</string>
             </property>
-           </widget>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+            <property name="prefix">
+             <string/>
             </property>
-            <property name="text">
-             <string>Camera settings (when available)</string>
+            <property name="minimum">
+             <number>10</number>
+            </property>
+            <property name="maximum">
+             <number>90</number>
             </property>
            </widget>
           </item>
@@ -368,99 +462,45 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="0">
-           <widget class="QLabel" name="label_12">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="cursor">
-             <cursorShape>WhatsThisCursor</cursorShape>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For LEDs, 'Natural' is the fastest grayscale mode thanks to optimized SIMD code. Color key allows to track regular pieces of colored paper.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Color channels used</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Dynamic pose (for caps only, never clips)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Device</string>
-            </property>
-            <property name="buddy">
-             <cstring>camdevice_combo</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Dynamic pose timeout</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_13">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="cursor">
-             <cursorShape>WhatsThisCursor</cursorShape>
-            </property>
-            <property name="toolTip">
-             <string>Enable MJPEG compression for high-speed cameras other than the PS3 Eye. Windows only.</string>
-            </property>
-            <property name="text">
-             <string>MJPEG compression</string>
-            </property>
-           </widget>
-          </item>
           <item row="10" column="0">
-           <widget class="QLabel" name="label_16">
+           <widget class="QLabel" name="label_17">
             <property name="text">
-             <string>Chroma key includes overexposed pixels</string>
+             <string>Chroma key strength</string>
             </property>
            </widget>
           </item>
           <item row="10" column="1">
-           <widget class="QCheckBox" name="chroma_key_overexposed">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QSlider" name="chroma_key_strength_slider">
+              <property name="minimum">
+               <number>5</number>
+              </property>
+              <property name="maximum">
+               <number>40</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="chroma_key_strength_label">
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+              <property name="buttonSymbols">
+               <enum>QAbstractSpinBox::NoButtons</enum>
+              </property>
+              <property name="minimum">
+               <double>0.500000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>4.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -616,6 +656,26 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="threshold_value_display">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="text">
+             <string>Value</string>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="1">
            <widget class="QDoubleSpinBox" name="mindiam_spin">
             <property name="sizePolicy">
@@ -635,26 +695,6 @@
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="threshold_value_display">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_14">
-            <property name="text">
-             <string>Value</string>
             </property>
            </widget>
           </item>
@@ -693,7 +733,7 @@
           <enum>QTabWidget::Rounded</enum>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>2</number>
          </property>
          <property name="usesScrollButtons">
           <bool>false</bool>
@@ -1649,32 +1689,6 @@ Don't roll or change position.</string>
       <string>Status</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_10">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Extracted Points:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_38">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Camera Info:</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="1">
        <widget class="QLabel" name="pointinfo_label">
         <property name="sizePolicy">
@@ -1698,6 +1712,32 @@ Don't roll or change position.</string>
         </property>
         <property name="text">
          <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Extracted Points:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_38">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Camera Info:</string>
         </property>
        </widget>
       </item>
@@ -1727,10 +1767,11 @@ Don't roll or change position.</string>
   <tabstop>fps_spin</tabstop>
   <tabstop>use_mjpeg</tabstop>
   <tabstop>fov</tabstop>
-  <tabstop>dynamic_pose</tabstop>
   <tabstop>init_phase_timeout</tabstop>
+  <tabstop>dynamic_pose</tabstop>
   <tabstop>camera_settings</tabstop>
   <tabstop>blob_color</tabstop>
+  <tabstop>chroma_key_overexposed</tabstop>
   <tabstop>auto_threshold</tabstop>
   <tabstop>threshold_slider</tabstop>
   <tabstop>mindiam_spin</tabstop>
@@ -1740,27 +1781,23 @@ Don't roll or change position.</string>
   <tabstop>clip_theight_spin</tabstop>
   <tabstop>clip_bheight_spin</tabstop>
   <tabstop>clip_blength_spin</tabstop>
-  <tabstop>cap_length_spin</tabstop>
-  <tabstop>cap_width_spin</tabstop>
-  <tabstop>cap_height_spin</tabstop>
-  <tabstop>m1x_spin</tabstop>
-  <tabstop>m1y_spin</tabstop>
-  <tabstop>m1z_spin</tabstop>
-  <tabstop>m2x_spin</tabstop>
-  <tabstop>m2y_spin</tabstop>
-  <tabstop>m2z_spin</tabstop>
   <tabstop>tx_spin</tabstop>
   <tabstop>ty_spin</tabstop>
   <tabstop>tz_spin</tabstop>
   <tabstop>tcalib_button</tabstop>
+  <tabstop>cap_length_spin</tabstop>
+  <tabstop>cap_width_spin</tabstop>
+  <tabstop>cap_height_spin</tabstop>
+  <tabstop>m1x_spin</tabstop>
+  <tabstop>m2x_spin</tabstop>
+  <tabstop>m1y_spin</tabstop>
+  <tabstop>m2y_spin</tabstop>
+  <tabstop>m1z_spin</tabstop>
+  <tabstop>m2z_spin</tabstop>
   <tabstop>enable_point_filter</tabstop>
   <tabstop>point_filter_slider</tabstop>
   <tabstop>point_filter_limit_slider</tabstop>
   <tabstop>point_filter_deadzone_slider</tabstop>
-  <tabstop>maxdiam_spin</tabstop>
-  <tabstop>mindiam_spin</tabstop>
-  <tabstop>auto_threshold</tabstop>
-  <tabstop>threshold_slider</tabstop>
  </tabstops>
  <resources>
   <include location="module/tracker_pt.qrc"/>

--- a/tracker-pt/FTNoIR_PT_Controls.ui
+++ b/tracker-pt/FTNoIR_PT_Controls.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>413</width>
-    <height>575</height>
+    <height>604</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -79,16 +79,48 @@
           <string>Camera settings</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="8" column="1">
-           <widget class="QPushButton" name="camera_settings">
+          <item row="4" column="1">
+           <widget class="QCheckBox" name="use_mjpeg">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_37">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>FPS</string>
+            </property>
+            <property name="buddy">
+             <cstring>fps_spin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="res_x_spin">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="text">
-             <string>Open</string>
+            <property name="toolTip">
+             <string>Desired capture width</string>
+            </property>
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="maximum">
+             <number>2000</number>
+            </property>
+            <property name="singleStep">
+             <number>10</number>
             </property>
            </widget>
           </item>
@@ -111,37 +143,53 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="label_9">
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="fps_spin">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="text">
-             <string>Camera settings (when available)</string>
+            <property name="toolTip">
+             <string>Desired capture framerate</string>
+            </property>
+            <property name="suffix">
+             <string> Hz</string>
+            </property>
+            <property name="maximum">
+             <number>2000</number>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_37">
+          <item row="6" column="1">
+           <widget class="QCheckBox" name="dynamic_pose">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
             <property name="text">
-             <string>FPS</string>
-            </property>
-            <property name="buddy">
-             <cstring>fps_spin</cstring>
+             <string/>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_36">
+          <item row="8" column="1">
+           <widget class="QPushButton" name="camera_settings">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Open</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_41">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
               <horstretch>0</horstretch>
@@ -149,7 +197,61 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Width</string>
+             <string>Height</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="camdevice_combo">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumContentsLength">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QSpinBox" name="init_phase_timeout">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="suffix">
+             <string> ms</string>
+            </property>
+            <property name="minimum">
+             <number>50</number>
+            </property>
+            <property name="maximum">
+             <number>5000</number>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="fov">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="suffix">
+             <string>°</string>
+            </property>
+            <property name="prefix">
+             <string/>
+            </property>
+            <property name="minimum">
+             <number>10</number>
+            </property>
+            <property name="maximum">
+             <number>90</number>
             </property>
            </widget>
           </item>
@@ -218,8 +320,8 @@
             </item>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_41">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_36">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
               <horstretch>0</horstretch>
@@ -227,12 +329,12 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Height</string>
+             <string>Width</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_5">
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_9">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
               <horstretch>0</horstretch>
@@ -240,20 +342,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Dynamic pose (for caps only, never clips)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QCheckBox" name="dynamic_pose">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string/>
+             <string>Camera settings (when available)</string>
             </property>
            </widget>
           </item>
@@ -298,98 +387,16 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="camdevice_combo">
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_5">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="minimumContentsLength">
-             <number>10</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QSpinBox" name="res_x_spin">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Desired capture width</string>
-            </property>
-            <property name="suffix">
-             <string> px</string>
-            </property>
-            <property name="maximum">
-             <number>2000</number>
-            </property>
-            <property name="singleStep">
-             <number>10</number>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QSpinBox" name="fps_spin">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Desired capture framerate</string>
-            </property>
-            <property name="suffix">
-             <string> Hz</string>
-            </property>
-            <property name="maximum">
-             <number>2000</number>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
-           <widget class="QSpinBox" name="init_phase_timeout">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="suffix">
-             <string> ms</string>
-            </property>
-            <property name="minimum">
-             <number>50</number>
-            </property>
-            <property name="maximum">
-             <number>5000</number>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QSpinBox" name="fov">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="suffix">
-             <string>°</string>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="minimum">
-             <number>10</number>
-            </property>
-            <property name="maximum">
-             <number>90</number>
+            <property name="text">
+             <string>Dynamic pose (for caps only, never clips)</string>
             </property>
            </widget>
           </item>
@@ -441,8 +448,15 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QCheckBox" name="use_mjpeg">
+          <item row="10" column="0">
+           <widget class="QLabel" name="label_16">
+            <property name="text">
+             <string>Chroma key includes overexposed pixels</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1">
+           <widget class="QCheckBox" name="chroma_key_overexposed">
             <property name="text">
              <string/>
             </property>

--- a/tracker-pt/ftnoir_tracker_pt_dialog.cpp
+++ b/tracker-pt/ftnoir_tracker_pt_dialog.cpp
@@ -110,9 +110,15 @@ TrackerDialog_PT::TrackerDialog_PT(const QString& module_name) :
 
     tie_setting(s.blob_color, ui.blob_color);
 
+    tie_setting(s.chroma_key_strength, ui.chroma_key_strength_slider);
+    connect(&s.chroma_key_strength, value_::value_changed<slider_value>(), ui.chroma_key_strength_label,
+            [this] { ui.chroma_key_strength_label->setValue(*s.chroma_key_strength); });
+    ui.chroma_key_strength_label->setValue(*s.chroma_key_strength);
+
     tie_setting(s.chroma_key_overexposed, ui.chroma_key_overexposed);
-    connect(ui.blob_color, &QComboBox::currentTextChanged, this, &TrackerDialog_PT::chroma_key_overexp_enable);
-    chroma_key_overexp_enable("");
+    connect(ui.blob_color, &QComboBox::currentTextChanged, this, &TrackerDialog_PT::chroma_key_controls_enable);
+
+    chroma_key_controls_enable("");
 
     tie_setting(s.threshold_slider, ui.threshold_value_display, [this](const slider_value& val) {
         return threshold_display_text(int(val));
@@ -252,16 +258,18 @@ void TrackerDialog_PT::show_camera_settings()
         (void)video::show_dialog(s.camera_name);
 }
 
-void TrackerDialog_PT::chroma_key_overexp_enable(const QString&)
+void TrackerDialog_PT::chroma_key_controls_enable(const QString&)
 {
+    bool enabled = false;
     QVariant data = ui.blob_color->currentData();
-    if (!data.isValid())
-        ui.chroma_key_overexposed->setEnabled(false);
-    else
+    if (data.isValid())
     {
         pt_color_type blob_color = pt_color_type(data.toInt());
-        ui.chroma_key_overexposed->setEnabled(blob_color >= pt_color_red_chromakey && blob_color <= pt_color_magenta_chromakey);
+        enabled = blob_color >= pt_color_red_chromakey && blob_color <= pt_color_magenta_chromakey;
     }
+    ui.chroma_key_strength_slider->setEnabled(enabled);
+    ui.chroma_key_strength_label->setEnabled(enabled);
+    ui.chroma_key_overexposed->setEnabled(enabled);
 }
 
 void TrackerDialog_PT::trans_calib_step()

--- a/tracker-pt/ftnoir_tracker_pt_dialog.cpp
+++ b/tracker-pt/ftnoir_tracker_pt_dialog.cpp
@@ -110,6 +110,10 @@ TrackerDialog_PT::TrackerDialog_PT(const QString& module_name) :
 
     tie_setting(s.blob_color, ui.blob_color);
 
+    tie_setting(s.chroma_key_overexposed, ui.chroma_key_overexposed);
+    connect(ui.blob_color, &QComboBox::currentTextChanged, this, &TrackerDialog_PT::chroma_key_overexp_enable);
+    chroma_key_overexp_enable("");
+
     tie_setting(s.threshold_slider, ui.threshold_value_display, [this](const slider_value& val) {
         return threshold_display_text(int(val));
     });
@@ -246,6 +250,18 @@ void TrackerDialog_PT::show_camera_settings()
         tracker->open_camera_dialog_flag = true;
     else
         (void)video::show_dialog(s.camera_name);
+}
+
+void TrackerDialog_PT::chroma_key_overexp_enable(const QString&)
+{
+    QVariant data = ui.blob_color->currentData();
+    if (!data.isValid())
+        ui.chroma_key_overexposed->setEnabled(false);
+    else
+    {
+        pt_color_type blob_color = pt_color_type(data.toInt());
+        ui.chroma_key_overexposed->setEnabled(blob_color >= pt_color_red_chromakey && blob_color <= pt_color_magenta_chromakey);
+    }
 }
 
 void TrackerDialog_PT::trans_calib_step()

--- a/tracker-pt/ftnoir_tracker_pt_dialog.h
+++ b/tracker-pt/ftnoir_tracker_pt_dialog.h
@@ -39,7 +39,7 @@ public slots:
     void poll_tracker_info_impl();
     void set_camera_settings_available(const QString& camera_name);
     void show_camera_settings();
-    void chroma_key_overexp_enable(const QString&);
+    void chroma_key_controls_enable(const QString&);
 
 protected:
     QString threshold_display_text(int threshold_value);

--- a/tracker-pt/ftnoir_tracker_pt_dialog.h
+++ b/tracker-pt/ftnoir_tracker_pt_dialog.h
@@ -39,6 +39,8 @@ public slots:
     void poll_tracker_info_impl();
     void set_camera_settings_available(const QString& camera_name);
     void show_camera_settings();
+    void chroma_key_overexp_enable(const QString&);
+
 protected:
     QString threshold_display_text(int threshold_value);
 

--- a/tracker-pt/lang/nl_NL.ts
+++ b/tracker-pt/lang/nl_NL.ts
@@ -304,6 +304,10 @@ Don&apos;t roll or change position.</source>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Chroma key includes overexposed pixels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/nl_NL.ts
+++ b/tracker-pt/lang/nl_NL.ts
@@ -308,6 +308,10 @@ Don&apos;t roll or change position.</source>
         <source>Chroma key includes overexposed pixels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Chroma key strength</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/ru_RU.ts
+++ b/tracker-pt/lang/ru_RU.ts
@@ -309,6 +309,10 @@ ROLL или X/Y-смещения.</translation>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Chroma key includes overexposed pixels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/ru_RU.ts
+++ b/tracker-pt/lang/ru_RU.ts
@@ -313,6 +313,10 @@ ROLL или X/Y-смещения.</translation>
         <source>Chroma key includes overexposed pixels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Chroma key strength</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/stub.ts
+++ b/tracker-pt/lang/stub.ts
@@ -304,6 +304,10 @@ Don&apos;t roll or change position.</source>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Chroma key includes overexposed pixels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/stub.ts
+++ b/tracker-pt/lang/stub.ts
@@ -308,6 +308,10 @@ Don&apos;t roll or change position.</source>
         <source>Chroma key includes overexposed pixels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Chroma key strength</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/zh_CN.ts
+++ b/tracker-pt/lang/zh_CN.ts
@@ -304,6 +304,10 @@ Don&apos;t roll or change position.</source>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Chroma key includes overexposed pixels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/lang/zh_CN.ts
+++ b/tracker-pt/lang/zh_CN.ts
@@ -308,6 +308,10 @@ Don&apos;t roll or change position.</source>
         <source>Chroma key includes overexposed pixels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Chroma key strength</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>pt_impl::TrackerDialog_PT</name>

--- a/tracker-pt/module/point_extractor.cpp
+++ b/tracker-pt/module/point_extractor.cpp
@@ -167,32 +167,38 @@ void PointExtractor::color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output)
     }
     case pt_color_red_chromakey:
     {
-        filter_single_channel(frame, 1, -0.5, -0.5, s.chroma_key_overexposed, output);
+        float non_key_coeff = -0.5 * *s.chroma_key_strength;
+        filter_single_channel(frame, 1, non_key_coeff, non_key_coeff, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_green_chromakey:
     {
-        filter_single_channel(frame, -0.5, 1, -0.5, s.chroma_key_overexposed, output);
+        float non_key_coeff = -0.5 * *s.chroma_key_strength;
+        filter_single_channel(frame, non_key_coeff, 1, non_key_coeff, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_blue_chromakey:
     {
-        filter_single_channel(frame, -0.5, -0.5, 1, s.chroma_key_overexposed, output);
+        float non_key_coeff = -0.5 * *s.chroma_key_strength;
+        filter_single_channel(frame, non_key_coeff, non_key_coeff, 1, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_cyan_chromakey:
     {
-        filter_single_channel(frame, -1, 0.5, 0.5, s.chroma_key_overexposed, output);
+        float non_key_coeff = -1.0 * *s.chroma_key_strength;
+        filter_single_channel(frame, non_key_coeff, 0.5, 0.5, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_yellow_chromakey:
     {
-        filter_single_channel(frame, 0.5, 0.5, -1, s.chroma_key_overexposed, output);
+        float non_key_coeff = -1.0 * *s.chroma_key_strength;
+        filter_single_channel(frame, 0.5, 0.5, non_key_coeff, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_magenta_chromakey:
     {
-        filter_single_channel(frame, 0.5, -1, 0.5, s.chroma_key_overexposed, output);
+        float non_key_coeff = -1.0 * *s.chroma_key_strength;
+        filter_single_channel(frame, 0.5, non_key_coeff, 0.5, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_hardware:

--- a/tracker-pt/module/point_extractor.cpp
+++ b/tracker-pt/module/point_extractor.cpp
@@ -148,6 +148,7 @@ void PointExtractor::color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output)
         return;
     }
 
+    const float half_chr_key_str = *s.chroma_key_strength * 0.5;
     switch (s.blob_color)
     {
     case pt_color_green_only:
@@ -167,38 +168,32 @@ void PointExtractor::color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output)
     }
     case pt_color_red_chromakey:
     {
-        float non_key_coeff = -0.5 * *s.chroma_key_strength;
-        filter_single_channel(frame, 1, non_key_coeff, non_key_coeff, s.chroma_key_overexposed, output);
+        filter_single_channel(frame, 1, -half_chr_key_str, -half_chr_key_str, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_green_chromakey:
     {
-        float non_key_coeff = -0.5 * *s.chroma_key_strength;
-        filter_single_channel(frame, non_key_coeff, 1, non_key_coeff, s.chroma_key_overexposed, output);
+        filter_single_channel(frame, -half_chr_key_str, 1, -half_chr_key_str, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_blue_chromakey:
     {
-        float non_key_coeff = -0.5 * *s.chroma_key_strength;
-        filter_single_channel(frame, non_key_coeff, non_key_coeff, 1, s.chroma_key_overexposed, output);
+        filter_single_channel(frame, -half_chr_key_str, -half_chr_key_str, 1, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_cyan_chromakey:
     {
-        float non_key_coeff = -1.0 * *s.chroma_key_strength;
-        filter_single_channel(frame, non_key_coeff, 0.5, 0.5, s.chroma_key_overexposed, output);
+        filter_single_channel(frame, -*s.chroma_key_strength, 0.5, 0.5, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_yellow_chromakey:
     {
-        float non_key_coeff = -1.0 * *s.chroma_key_strength;
-        filter_single_channel(frame, 0.5, 0.5, non_key_coeff, s.chroma_key_overexposed, output);
+        filter_single_channel(frame, 0.5, 0.5, -*s.chroma_key_strength, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_magenta_chromakey:
     {
-        float non_key_coeff = -1.0 * *s.chroma_key_strength;
-        filter_single_channel(frame, 0.5, non_key_coeff, 0.5, s.chroma_key_overexposed, output);
+        filter_single_channel(frame, 0.5, -*s.chroma_key_strength, 0.5, s.chroma_key_overexposed, output);
         break;
     }
     case pt_color_hardware:

--- a/tracker-pt/module/point_extractor.h
+++ b/tracker-pt/module/point_extractor.h
@@ -51,7 +51,7 @@ private:
     void ensure_buffers(const cv::Mat& frame);
 
     void extract_single_channel(const cv::Mat& orig_frame, int idx, cv::Mat1b& dest);
-    void filter_single_channel(const cv::Mat& orig_frame, float r, float g, float b, cv::Mat1b& dest);
+    void filter_single_channel(const cv::Mat& orig_frame, float r, float g, float b, bool overexp, cv::Mat1b& dest);
 
     void color_to_grayscale(const cv::Mat& frame, cv::Mat1b& output);
     void threshold_image(const cv::Mat& frame_gray, cv::Mat1b& output);

--- a/tracker-pt/pt-settings.hpp
+++ b/tracker-pt/pt-settings.hpp
@@ -65,6 +65,7 @@ struct pt_settings final : options::opts
     value<bool> auto_threshold { b, "automatic-threshold", true };
     value<pt_color_type> blob_color { b, "blob-color", pt_color_bt709 };
     value<bool> use_mjpeg { b, "use-mjpeg", false };
+    value<slider_value> chroma_key_strength{ b, "chroma-key-strength", { 1.0, 0.5, 4. } };
     value<bool> chroma_key_overexposed{ b, "chroma-key-overexposed", false };
 
     value<slider_value> threshold_slider { b, "threshold-slider", { 128, 0, 255 } };

--- a/tracker-pt/pt-settings.hpp
+++ b/tracker-pt/pt-settings.hpp
@@ -65,6 +65,7 @@ struct pt_settings final : options::opts
     value<bool> auto_threshold { b, "automatic-threshold", true };
     value<pt_color_type> blob_color { b, "blob-color", pt_color_bt709 };
     value<bool> use_mjpeg { b, "use-mjpeg", false };
+    value<bool> chroma_key_overexposed{ b, "chroma-key-overexposed", false };
 
     value<slider_value> threshold_slider { b, "threshold-slider", { 128, 0, 255 } };
 


### PR DESCRIPTION
I have been trying to use chroma key to isolate the light from green LEDs on my headset clip. However the middle of the LEDs is so bright that it is overexposed on the camera and the color fades to white. i.e. I get white blobs with green halos. The chroma key logic sees this as dark blobs surrounded by light halos. This confuses the subsequent thresholding logic. I can turn down the camera exposure but this results in very small blobs and these decrease point tracker's accuracy.

This PR adds an option for chroma key to detect overexposed pixels as the requested color when using any of the chroma key colors. This works really well.

Using green as an example, the logic change is...

Existing logic: every pixel is transformed to a grayscale value with the formula `G - 0.5 * (R + B)`. (Where `R`, `G` and `B` and the red, green and blue channel intensities.) Subsequently a threshold is applied. The greener a pixel, the more likely the transformed value is to exceed the threshold.

New logic: The green channel intensity is used to calculate a weighted average between the green channel and the grayscale value calculated above. So the new formula is `G/255 * G + (1 - G/255) * (G - 0.5 * (R + B))`. This simplifies to `G - 0.5 * (R + B) + G/255 * 0.5 * (R + B)`, which is the existing chroma grayscale value plus `G/255 * 0.5 * (R + B)`.

With the new logic, the closer G is to 255, the less color saturation is expected from the pixel.

I have also added a checkbox to the options which is enabled when chroma key is selected. This allows either the new or the existing logic to be selected. It defaults to the existing logic so that a new version of opentrack would not change the behaviour without the user specifically requesting it.