### PR TITLE
Efficient wait in SimConnect thread

### DIFF
--- a/proto-simconnect/ftnoir_protocol_sc.cpp
+++ b/proto-simconnect/ftnoir_protocol_sc.cpp
@@ -53,7 +53,7 @@ void simconnect::run()
                 {
                     constexpr int max_idle_seconds = 2;
 
-                    if (WaitForSingleObject(event, 0) == WAIT_OBJECT_0)
+                    if (WaitForSingleObject(event, 1) == WAIT_OBJECT_0)
                         tm.start();
 
                     if ((int)tm.elapsed_seconds() > max_idle_seconds)

--- a/proto-simconnect/ftnoir_protocol_sc.h
+++ b/proto-simconnect/ftnoir_protocol_sc.h
@@ -47,8 +47,6 @@ public:
     void run() override;
 
 private:
-    void handler();
-
     enum {
         SIMCONNECT_RECV_ID_EXCEPTION = 2,
         SIMCONNECT_RECV_ID_QUIT = 3,


### PR DESCRIPTION
The SimConnect thread runs at 100% CPU (i.e. it ties up one CPU core), reducing CPU resources available for the simulator. This behaviour is verified with FSX and, unless `SimConnect_CallDispatch()` is a blocking function on other simulators like P3D or MSFS, will do the same there as well.

This PR contains two commits. The first adds a non-zero timeout to the `WaitForSingleObject()` call in `simconnect::run()`. This resolves the CPU usage problem but re-introduces the possibility that a context switch may delay responding to the Frame event which was removed in commit https://github.com/opentrack/opentrack/commit/c26423c613619a40df81a3cd30870e4ef2784007. This can lead to jitter.

The second commit does away with waiting for Frame events as a trigger for sending 6D position updates to SimConnect and simply sends the updates whenever the pipeline thread calls `simconnect::pose()`. As far as I can tell, SimConnect is threadsafe and position updates can be sent from any thread so this is the best way to avoid jitter.

I have tested on FSX but I would like to know this also works on P3D and MSFS before it is merged.