### PR TITLE
Migrate to procps-ng 4.0

### DIFF
--- a/compat/process-list.hpp
+++ b/compat/process-list.hpp
@@ -139,24 +139,31 @@ QStringList get_all_executable_names()
 {
     QStringList ret;
     enum pids_item items[] = { PIDS_ID_PID, PIDS_CMD, PIDS_CMDLINE_V };
+
     enum rel_items { rel_pid, rel_cmd, rel_cmdline };
     struct pids_info *info = NULL;
     struct pids_stack *stack;
+    QString tmp; tmp.reserve(64);
 
     procps_pids_new(&info, items, 3);
 
-    while ((stack = procps_pids_get(info, PIDS_FETCH_TASKS_ONLY))) {
+    while ((stack = procps_pids_get(info, PIDS_FETCH_TASKS_ONLY)))
+    {
         char  **p_cmdline = PIDS_VAL(rel_cmdline, strv,  stack, info);
 
         // note, wine sets argv[0] so no parsing like in OSX case
-        if (p_cmdline && p_cmdline[0])
+        if (p_cmdline && p_cmdline[0] && p_cmdline[0][0] &&
+                !(p_cmdline[0][0] == '-' && !p_cmdline[0][1]))
         {
-            QString tmp(p_cmdline[0]);
+            tmp = QString{p_cmdline[0]};
             const int idx = std::max(tmp.lastIndexOf('\\'), tmp.lastIndexOf('/'));
-            tmp = tmp.mid(idx == -1 ? 0 : idx+1);
+            if (idx != -1)
+                tmp = tmp.mid(idx+1);
+            //qDebug() << "procps" << tmp;
             ret.append(tmp);
         }
     }
+    //qDebug() << "-- procps end";
 
     procps_pids_unref(&info);
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(${self}
 if(APPLE)
     target_link_libraries(${self} proc)
 elseif(LINUX)
-    otr_pkgconfig(${self} libprocps)
+    otr_pkgconfig(${self} libproc2)
 endif()
 
 if(NOT APPLE AND NOT WIN32)


### PR DESCRIPTION
I've tried to make the changes needed for procps-ng 4.0. This is the first time I touch any procps related code. I'm not sure how good are the changes. Needs testing.