### PR TITLE
Allow arm64 build in macOS by using toolchain file apple.cmake and e…

### DIFF
--- a/cmake/apple.cmake
+++ b/cmake/apple.cmake
@@ -1,12 +1,19 @@
 set(CMAKE_BUILD_TYPE_INIT RELEASE)
 
-set(CMAKE_CXX_FLAGS "-arch x86_64 -stdlib=libc++" CACHE STRING "" FORCE)
-set(CMAKE_C_FLAGS "-arch x86_64" CACHE STRING "" FORCE)
+if("$ENV{OTR_OSX_ARCH}" STREQUAL "arm64")
+ set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "" FORCE)
+ set(opentrack-intel FALSE)
+else()
+ set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "" FORCE)
+ set(opentrack-intel TRUE)
+endif()
+
+set(CMAKE_CXX_FLAGS "-stdlib=libc++" CACHE STRING "" FORCE)
 
 set(CMAKE_C_FLAGS_RELEASE "-ffast-math -O3 -flto -g" CACHE STRING "" FORCE)
 set(CMAKE_CXX_FLAGS_RELEASE " ${CMAKE_C_FLAGS_RELEASE}" CACHE STRING "" FORCE)
 
-set(cmake-link-common "-stdlib=libc++ -arch x86_64")
+set(cmake-link-common "-stdlib=libc++")
 set(CMAKE_EXE_LINKER_FLAGS "${cmake-link-common} -Wl,-stack_size,0x4000000" CACHE STRING "" FORCE)
 set(CMAKE_SHARED_LINKER_FLAGS ${cmake-link-common} CACHE STRING "" FORCE)
 set(CMAKE_MODULE_LINKER_FLAGS ${cmake-link-common} CACHE STRING "" FORCE)

--- a/gui/init.cpp
+++ b/gui/init.cpp
@@ -50,7 +50,9 @@ static void set_fp_mask()
 #endif
 
 #ifdef __APPLE__
+#if defined __i386__ || defined __x86_64__
     fesetenv(FE_DFL_DISABLE_SSE_DENORMS_ENV);
+#endif
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
Hi,

I successfully built an apple silicon build of opentrack. I offer you my changes.

After cloning the repo, I build like this:

cd opentrack
export OTR_OSX_ARCH=arm64 ; cmake --toolchain ./cmake/apple.cmake -S . -B build
cd build
make install

The product works fine on macOS Ventura on a MacBook M1. Still builds on my Intel Mac. Of course I don't set the environment variable there, because qt5 would not link.

I had installed qt5 (5.15.10) via mac-ports.