### PR TITLE
tracker/tobii: Downgrade SDK to v2

### DIFF
--- a/tracker-tobii/CMakeLists.txt
+++ b/tracker-tobii/CMakeLists.txt
@@ -3,10 +3,16 @@ set(SDK_TOBII "" CACHE PATH "Tobii Stream Engine path")
 if(WIN32 AND SDK_TOBII)
     otr_module(tracker-tobii)
 
-    target_include_directories(${self} SYSTEM PRIVATE "${SDK_TOBII}/include")
-    target_link_directories(${self} PRIVATE "${SDK_TOBII}/lib/tobii")
+    if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
+        set(arch "x86")
+    else()
+        set(arch "x64")
+    endif()
 
-    set(dll "${SDK_TOBII}/lib/tobii/tobii_stream_engine.dll")
+    target_include_directories(${self} SYSTEM PRIVATE "${SDK_TOBII}/include")
+    target_link_directories(${self} PRIVATE "${SDK_TOBII}/lib/${arch}")
+
+    set(dll "${SDK_TOBII}/lib/${arch}/tobii_stream_engine.dll")
     set(lib tobii_stream_engine.lib)
 
     target_link_libraries(${self} ${lib})

--- a/tracker-tobii/tobii.cpp
+++ b/tracker-tobii/tobii.cpp
@@ -64,7 +64,7 @@ module_status tobii_tracker::start_tracker(QFrame*)
         return error("No stream engine compatible device(s) found.");
     }
 
-    tobii_error = tobii_device_create(api, url, TOBII_FIELD_OF_USE_INTERACTIVE, &device);
+    tobii_error = tobii_device_create(api, url, &device);
     if (tobii_error != TOBII_ERROR_NO_ERROR)
     {
         tobii_api_destroy(api);


### PR DESCRIPTION
Downgrade SDK to v2 to support 32-bit build