### PR TITLE
tracker/nn: Fix 180 deg roll

### DIFF
--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
@@ -652,7 +652,7 @@ void NeuralNetTracker::data(double *data)
 
     const auto& mx = tmp.R.col(0);
     const auto& my = tmp.R.col(1);
-    const auto& mz = -tmp.R.col(2);
+    const auto& mz = tmp.R.col(2);
 
     const float yaw = std::atan2(mx(2), mx(0));
     const float pitch = -std::atan2(-mx(1), std::sqrt(mx(2)*mx(2)+mx(0)*mx(0)));


### PR DESCRIPTION
Hi @sthalik ,

this should fix the 180 degree roll offset of the NN tracker. (https://github.com/opentrack/opentrack/issues/1728)

Actually I've been playing with it based on an older master branch. So, unless you changed something related in the meantime, I'm pretty confident it'll do the trick.