### PR TITLE
Add DBus interfaces for controlling tracker

### DIFF
--- a/cmake/opentrack-qt.cmake
+++ b/cmake/opentrack-qt.cmake
@@ -17,6 +17,14 @@ if(TRUE OR NOT APPLE AND NOT WINDOWS)
     endif()
 endif()
 
+set(OPENTRACK_DBUS_CONTROL CACHE BOOL "Expose DBus services for control purposes")
+if(OPENTRACK_DBUS_CONTROL)
+    add_definitions(-DOTR_DBUS_CONTROL)
+
+    list(APPEND qt-required-components "DBus")
+    list(APPEND qt-imported-targets Qt6::DBus)
+endif()
+
 find_package(Qt6 REQUIRED COMPONENTS ${qt-required-components} QUIET)
 find_package(Qt6 COMPONENTS ${qt-optional-components} QUIET)
 

--- a/logic/dbus.cpp
+++ b/logic/dbus.cpp
@@ -1,0 +1,28 @@
+#if defined OTR_DBUS_CONTROL
+#include "dbus.hpp"
+
+bool DBus::is_enabled() const
+{
+    return pipeline_->is_enabled();
+}
+
+bool DBus::is_zero() const
+{
+    return pipeline_->is_zero();
+}
+
+void DBus::Center()
+{
+    pipeline_->set_center(true);
+}
+
+void DBus::ToggleEnabled()
+{
+    pipeline_->toggle_enabled();
+}
+
+void DBus::ToggleZero()
+{
+    pipeline_->toggle_zero();
+}
+#endif

--- a/logic/dbus.hpp
+++ b/logic/dbus.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#if defined OTR_DBUS_CONTROL
+
+#include "export.hpp"
+#include "pipeline.hpp"
+
+#include <QDBusAbstractAdaptor>
+#include <QDBusConnection>
+#include <QDBusError>
+
+class OTR_LOGIC_EXPORT DBus final : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "com.github.opentrack.Tracker")
+
+    Q_PROPERTY(bool IsEnabled READ is_enabled)
+    Q_PROPERTY(bool IsZeroed READ is_zero)
+
+    pipeline* pipeline_;
+
+public:
+    static constexpr const char* SERVICE_NAME = "com.github.opentrack";
+    static constexpr const char* SERVICE_PATH = "/com/github/opentrack/Tracker";
+
+    DBus(QObject* obj, pipeline* pipeline)
+        : QDBusAbstractAdaptor(obj)
+        , pipeline_(pipeline)
+    { }
+    ~DBus() = default;
+
+    bool is_enabled() const;
+    bool is_zero() const;
+
+public slots:
+    Q_SCRIPTABLE Q_NOREPLY void Center();
+    Q_SCRIPTABLE Q_NOREPLY void ToggleEnabled();
+    Q_SCRIPTABLE Q_NOREPLY void ToggleZero();
+};
+
+#endif

--- a/logic/pipeline.cpp
+++ b/logic/pipeline.cpp
@@ -689,7 +689,9 @@ void pipeline::set_enabled(bool value) { b.set(f_enabled_h, value); }
 void pipeline::set_zero(bool value) { b.set(f_zero, value); }
 
 void pipeline::toggle_zero() { b.negate(f_zero); }
+bool pipeline::is_zero() const { return !!(b.flags & f_zero); }
 void pipeline::toggle_enabled() { b.negate(f_enabled_p); }
+bool pipeline::is_enabled() const { return !!(b.flags & f_enabled_p); }
 
 void bits::set(bit_flags flag, bool val)
 {

--- a/logic/pipeline.hpp
+++ b/logic/pipeline.hpp
@@ -119,8 +119,6 @@ class OTR_LOGIC_EXPORT pipeline : private QThread
     Pose apply_reltrans(Pose value, vec6_bool disabled, bool centerp);
     Pose apply_zero_pos(Pose value) const;
 
-    void set_center(bool x);
-
     bits b;
 
 public:
@@ -131,8 +129,11 @@ public:
     void start() { QThread::start(QThread::HighPriority); }
 
     void toggle_zero();
+    bool is_zero() const;
     void toggle_enabled();
+    bool is_enabled() const;
 
+    void set_center(bool value);
     void set_held_center(bool value);
     void set_enabled(bool value);
     void set_zero(bool value);

--- a/logic/work.hpp
+++ b/logic/work.hpp
@@ -11,6 +11,7 @@
 #include "main-settings.hpp"
 #include "api/plugin-support.hpp"
 #include "pipeline.hpp"
+#include "dbus.hpp"
 #include "input/shortcuts.h"
 #include "export.hpp"
 #include "tracklogger.hpp"
@@ -42,6 +43,10 @@ public:
     std::unique_ptr<TrackLogger> logger { make_logger(s) }; // must come before pipeline, since pipeline depends on it
     pipeline pipeline_;
     Shortcuts sc;
+#if defined OTR_DBUS_CONTROL
+    QObject dbus_obj;
+    DBus dbus_;
+#endif
 
     std::vector<key_tuple> keys {
         // third argument means "keydown only"
@@ -62,5 +67,6 @@ public:
     Work(const Mappings& m, QFrame* frame,
          const dylibptr& tracker, const dylibptr& filter, const dylibptr& proto);
     void reload_shortcuts();
+    void connect_dbus();
     bool is_ok() const;
 };

--- a/opentrack/dbus.cpp
+++ b/opentrack/dbus.cpp
@@ -1,0 +1,29 @@
+#if defined OTR_DBUS_CONTROL
+#include "dbus.hpp"
+#include "main-window.hpp"
+
+bool MainDBus::tracker_running() const
+{
+    return window_->tracker_running();
+}
+
+void MainDBus::StartTracker()
+{
+    window_->start_tracker_();
+}
+
+void MainDBus::StopTracker()
+{
+    window_->stop_tracker_();
+}
+
+void MainDBus::RestartTracker()
+{
+    window_->restart_tracker_();
+}
+
+void MainDBus::ToggleTracker()
+{
+    window_->toggle_tracker_();
+}
+#endif

--- a/opentrack/dbus.hpp
+++ b/opentrack/dbus.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#if defined OTR_DBUS_CONTROL
+
+#include <QDBusAbstractAdaptor>
+#include <QDBusConnection>
+#include <QDBusError>
+
+class main_window;
+
+class MainDBus final : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "com.github.opentrack")
+
+    Q_PROPERTY(bool IsTrackerRunning READ tracker_running)
+
+    main_window* window_;
+
+public:
+    static constexpr const char* SERVICE_NAME = "com.github.opentrack";
+    static constexpr const char* SERVICE_PATH = "/com/github/opentrack";
+
+    MainDBus(QObject* obj, main_window* window)
+        : QDBusAbstractAdaptor(obj)
+        , window_(window)
+    { }
+    ~MainDBus() = default;
+
+    bool tracker_running() const;
+
+public slots:
+    Q_SCRIPTABLE Q_NOREPLY void StartTracker();
+    Q_SCRIPTABLE Q_NOREPLY void StopTracker();
+    Q_SCRIPTABLE Q_NOREPLY void RestartTracker();
+    Q_SCRIPTABLE Q_NOREPLY void ToggleTracker();
+};
+
+#endif

--- a/opentrack/main-window.cpp
+++ b/opentrack/main-window.cpp
@@ -45,7 +45,11 @@ extern "C" const char* const opentrack_version;
 using namespace options::globals;
 using namespace options;
 
-main_window::main_window() : State(OPENTRACK_BASE_PATH + OPENTRACK_LIBRARY_PATH)
+main_window::main_window()
+    : State(OPENTRACK_BASE_PATH + OPENTRACK_LIBRARY_PATH)
+#if defined OTR_DBUS_CONTROL
+    , dbus(&dbus_obj, this)
+#endif
 {
     ui.setupUi(this);
 
@@ -61,6 +65,7 @@ main_window::main_window() : State(OPENTRACK_BASE_PATH + OPENTRACK_LIBRARY_PATH)
     init_buttons();
     init_dylibs();
     init_shortcuts();
+    init_dbus();
 
     init_tray_menu();
     setVisible(!start_in_tray());
@@ -272,6 +277,18 @@ void main_window::init_buttons()
 #endif
     connect(ui.btnStartTracker, &QPushButton::clicked, this, &main_window::start_tracker_);
     connect(ui.btnStopTracker, &QPushButton::clicked, this, &main_window::stop_tracker_);
+}
+
+void main_window::init_dbus()
+{
+#if defined OTR_DBUS_CONTROL
+    qDebug() << "dbus: attaching main service";
+    QDBusConnection::sessionBus().registerObject(MainDBus::SERVICE_PATH, &dbus_obj);
+    if (!QDBusConnection::sessionBus().registerService(MainDBus::SERVICE_NAME))
+    {
+        qDebug() << "dbus: " << QDBusConnection::sessionBus().lastError().message();
+    }
+#endif
 }
 
 void main_window::register_shortcuts()
@@ -539,6 +556,11 @@ void main_window::stop_tracker_()
     update_button_state(false, false);
     set_title();
     ui.btnStartTracker->setFocus();
+}
+
+bool main_window::tracker_running() const
+{
+    return !!work;
 }
 
 void main_window::show_pose_(const double* mapped, const double* raw)

--- a/opentrack/main-window.hpp
+++ b/opentrack/main-window.hpp
@@ -20,6 +20,7 @@
 #include "logic/state.hpp"
 #include "options/options.hpp"
 #include "compat/qt-signal.hpp"
+#include "dbus.hpp"
 
 #include <QMainWindow>
 #include <QKeySequence>
@@ -50,6 +51,11 @@ class main_window final : public QMainWindow, private State
 
     std::unique_ptr<Shortcuts> global_shortcuts;
     QShortcut kbd_quit { QKeySequence("Ctrl+Q"), this };
+
+#if defined OTR_DBUS_CONTROL
+    QObject dbus_obj;
+    MainDBus dbus;
+#endif
 
 #ifdef UI_NO_VIDEO_FEED
     QWidget fake_video_frame_parent;
@@ -89,6 +95,7 @@ public:
     void init_tray_menu();
     void init_profiles();
     void init_buttons();
+    void init_dbus();
 
     void init_shortcuts();
     void register_shortcuts();
@@ -123,6 +130,7 @@ public:
     void stop_tracker_();
     void restart_tracker_();
     void toggle_tracker_();
+    bool tracker_running() const;
 
     [[nodiscard]] bool create_profile_from_preset(const QString& name);
     void set_profile(const QString& new_name, bool migrate = true);


### PR DESCRIPTION
I was finding some issues in properly binding the handling of the tracker on my local system, so I decided to hack together a quick set of DBus interfaces to make that particular thing easier to accomplish.

This exposes two interfaces on the session bus, `com.github.opentrack` which deals with starting/stopping the tracker, and - when the tracker is running - `com.github.opentrack.Tracker` which handles centering/enabling/zeroing the running tracker.

I had to expose the `set_center` function on the tracker pipeline, since DBus does best when working with momentary inputs. I also added some read-only properties to allow checking the states of toggles through the DBus interface.