### PR TITLE
Fix compatibility with Proton 9.0 and up

### DIFF
--- a/proto-wine/ftnoir_protocol_wine.cpp
+++ b/proto-wine/ftnoir_protocol_wine.cpp
@@ -87,11 +87,13 @@ module_status wine::initialize()
         if (s.proton_appid == 0)
             return error(tr("Must specify application id for Proton (Steam Play)"));
 
-        std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString& proton_path, int appid);
-        QString proton_path(const QString& proton_path);
+        std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString& proton_dist_path, int appid);
+        QString proton_path(const QString& proton_dist_path);
 
-        wine_path = proton_path(s.proton_path().toString());
-        auto [proton_env, error_string, success] = make_steam_environ(s.proton_path().toString(), s.proton_appid);
+        QString proton_dist_path = s.proton_path().toString();
+
+        wine_path = proton_path(proton_dist_path);
+        auto [proton_env, error_string, success] = make_steam_environ(proton_dist_path, s.proton_appid);
         env = proton_env;
 
         if (!success)

--- a/proto-wine/ftnoir_protocol_wine_dialog.cpp
+++ b/proto-wine/ftnoir_protocol_wine_dialog.cpp
@@ -2,6 +2,9 @@
 #include <QDebug>
 #include <QFileDialog>
 #include <QDir>
+#include <QDirIterator>
+#include <qdebug.h>
+#include <qdir.h>
 
 #include "api/plugin-api.hpp"
 
@@ -46,12 +49,26 @@ FTControls::FTControls()
         QDir dir(QDir::homePath() + path);
         dir.setFilter(QDir::Dirs);
         dir.setNameFilters({ "Proton*" });
-        QFileInfoList list = dir.entryInfoList();
-        for (int i = 0; i < list.size(); ++i) {
-            QFileInfo fileInfo = list.at(i);
-            ui.proton_version->addItem(fileInfo.fileName(), QVariant{fileInfo.filePath()});
+
+        QFileInfoList proton_dir_list = dir.entryInfoList();
+        for (int i = 0; i < proton_dir_list.size(); ++i) {
+            const QFileInfo &proton_dir = proton_dir_list.at(i);
+            qDebug() << proton_dir.canonicalFilePath();
+
+            QDirIterator proton_executable_it(proton_dir.canonicalFilePath(), QStringList() << "wine", QDir::Files, QDirIterator::Subdirectories);
+
+            if (proton_executable_it.hasNext()) {
+                QString proton_executable_path = proton_executable_it.next();
+                QDir proton_dist_dir(proton_executable_path);
+                proton_dist_dir.cd("../../");
+
+                qDebug() << proton_dist_dir.canonicalPath();
+
+                ui.proton_version->addItem(proton_dir.fileName(), QVariant{proton_dist_dir.canonicalPath()});
+            }
         }
     }
+
 
     tie_setting(s.proton_path, ui.proton_version);
     tie_setting(s.variant_wine, ui.variant_wine);

--- a/proto-wine/proton.cpp
+++ b/proto-wine/proton.cpp
@@ -25,7 +25,7 @@ static const char* runtime_paths[] = {
 };
 
 
-std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString& proton_path, int appid)
+std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString& proton_dist_path, int appid)
 {
     using ret = std::tuple<QProcessEnvironment, QString, bool>;
     auto env = QProcessEnvironment::systemEnvironment();
@@ -35,7 +35,7 @@ std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString&
 
     auto expand = [&](QString x) {
                       x.replace("HOME", home);
-                      x.replace("PROTON_PATH", proton_path);
+                      x.replace("PROTON_DIST_PATH", proton_dist_path);
                       x.replace("RUNTIME_PATH", runtime_path);
                       return x;
                   };
@@ -58,14 +58,15 @@ std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString&
         error = QString("Couldn't find a Wineprefix for AppId %1").arg(appid);
 
     QString path = expand(
-        ":PROTON_PATH/dist/bin"
+        ":PROTON_DIST_PATH/bin"
+        ":PROTON_DIST_PATH/bin"
     );
     path += ':'; path += qgetenv("PATH");
     env.insert("PATH", path);
 
     QString library_path = expand(
-        ":PROTON_PATH/dist/lib"
-        ":PROTON_PATH/dist/lib64"
+        ":PROTON_DIST_PATH/lib"
+        ":PROTON_DIST_PATH/lib64"
         ":RUNTIME_PATH/pinned_libs_32"
         ":RUNTIME_PATH/pinned_libs_64"
         ":RUNTIME_PATH/i386/lib/i386-linux-gnu"
@@ -84,9 +85,9 @@ std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString&
     return ret(env, error, error.isEmpty());
 }
 
-QString proton_path(const QString& proton_path)
-{
-    return proton_path + "/dist/bin/wine";
-}
 
+QString proton_path(const QString& proton_dist_path)
+{
+    return proton_dist_path + "/bin/wine";
+}
 #endif

--- a/proto-wine/proton.cpp
+++ b/proto-wine/proton.cpp
@@ -59,7 +59,6 @@ std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString&
 
     QString path = expand(
         ":PROTON_DIST_PATH/bin"
-        ":PROTON_DIST_PATH/bin"
     );
     path += ':'; path += qgetenv("PATH");
     env.insert("PATH", path);


### PR DESCRIPTION
## Problem
From Proton 9.0 and up, the directory containing library files and wine executable - previously called `dist`, appears to have been renamed to `files`. This breaks OpenTrack with newer Proton versions, because the path to the `wine` executable and proton library files is constructed as `:PROTON_PATH/dist/bin/wine`, so the executable is never found and tracking cannot be launched.

Proton 8.0 (note `dist`):
```bash
kiril@localhost ~/.l/s/S/s/common> ls Proton\ 8.0/
dist/       filelock.py*  LICENSE.OFL*  proton*                    proton_dist.tar*  toolmanifest.vdf*         version*
dist.lock*  LICENSE*      PATENTS.AV1*  proton_3.7_tracked_files*  __pycache__/      user_settings.sample.py*
```

Proton 9.0 (Beta) (`dist` is replaced by `files`):
```bash
kiril@localhost ~/.l/s/S/s/common> ls Proton\ 9.0\ \(Beta\)/
dist.lock*    files/    LICENSE.OFL*  proton*                    __pycache__/            steampipe_fixups.py*  user_settings.sample.py*
filelock.py*  LICENSE*  PATENTS.AV1*  proton_3.7_tracked_files*  steampipe_fixups.json*  toolmanifest.vdf*     version*
```

## Fix
To fix this while preserving backward compatibility, this commit changes `proton_path` to point to the `dist` dir directly, be it `files` for 9.0+ or `dist` for older versions. Template strings are adjusted accordingly, mostly removing the hardcoded `dist` part; as far as I can tell, the common parent dir for every path constructed from `proton_path` is the dist dir itself, so it seemed appropriate to fully replace the value of the original parameter, rather than introducing a new one.

Obtaining the dist. dir path for a specific Proton version is done by recursively iterating the version's directory, looking for the `wine` executable. The first match is used to discover the grandparent dir path, which is the desired `:PROTON_PATH/:DIST_DIR` path. This also means that only usable Proton directories - with a `wine` exectutable - will be listed in the dialog dropdown.

## Testing
I've built and tested this manually on OpenSuse Tumbleweed, with [Falcon BMS 4.37.4](https://www.falcon-bms.com/), [Nuclear Option](https://store.steampowered.com/app/2168680/Nuclear_Option/), and [DCS World Steam Edition](https://store.steampowered.com/app/223750/DCS_World_Steam_Edition/). Falcon BMS 4.37.4 is what led me to discover this issue, as Update 4 requires Proton 9.0+ for the alternative launcher to work, which broke my head tracking.

### Disclaimer
This is my first C++ in 15 years and first ever experience with Qt, so the code is likely far from idiomatic; happy to update with any suggestions.