### PR TITLE
filter/accelahamilton: rewrite in double precision

### DIFF
--- a/filter-accela-hamilton/accela_hamilton.h
+++ b/filter-accela-hamilton/accela_hamilton.h
@@ -13,11 +13,11 @@
 #include "api/plugin-api.hpp"
 #include "compat/timer.hpp"
 #include "compat/variance.hpp"
+#include "compat/hamilton-tools.h"
 
 #include <QMutex>
 #include <QTimer>
-#include <QQuaternion>
-#include <QVector3D>
+
 
 //#define DEBUG_ACCELA
 
@@ -30,8 +30,8 @@ struct accela_hamilton : IFilter
     module_status initialize() override { return status_ok(); }
 private:
     settings_accela_hamilton s;
-    QVector3D last_position = {};
-    QQuaternion last_rotation = {};
+    tVector last_position = {};
+    tQuat last_rotation = {};
     Timer t;
 #if defined DEBUG_ACCELA
     Timer debug_timer;


### PR DESCRIPTION
Self explanatory.

Reason: strange stuttering motion after a while that I observed with this filter, but not with Accela.
Also, the Accela and Hamilton filter are written in double precision. So it's probably better to not take chances for bad result due to limited precision of float.

Maybe it's confirmation bias but I think the output is nice and smooth now.

Thanks @tombrazier and @GO63-samara for the math library :-D