### PR TITLE
Extend Proton Support in the proto-wine module

### DIFF
--- a/proto-wine/ftnoir_protocol_wine.cpp
+++ b/proto-wine/ftnoir_protocol_wine.cpp
@@ -108,9 +108,6 @@ module_status wine::initialize()
     // if proton is used setup proton environment
     if (s.variant_proton)
     {
-        if (s.proton_appid == 0)
-            return error(tr("Must specify application id for Proton (Steam Play)"));
-
         auto [proton_env, env_error_string, env_success] = make_steam_environ(s.proton_path().toString());
         env = proton_env;
 
@@ -122,6 +119,9 @@ module_status wine::initialize()
     if (s.variant_proton && s.variant_proton_steamplay) {
         // wine prefix is dependend on steam
 
+        if (s.proton_appid == 0)
+            return error(tr("Must specify application id for Proton (Steam Play)"));
+        
         auto [prefix, error_string, success] = make_wineprefix(s.proton_appid);
         qDebug() << "proto/wine: wineprefix:" << prefix;
         env.insert("WINEPREFIX", prefix);

--- a/proto-wine/ftnoir_protocol_wine.cpp
+++ b/proto-wine/ftnoir_protocol_wine.cpp
@@ -123,6 +123,7 @@ module_status wine::initialize()
         // wine prefix is dependend on steam
 
         auto [prefix, error_string, success] = make_wineprefix(s.proton_appid);
+        qDebug() << "proto/wine: wineprefix:" << prefix;
         env.insert("WINEPREFIX", prefix);
 
         if (!success)
@@ -171,7 +172,7 @@ module_status wine::initialize()
     ////////////////////////////////
     // launch the wrapper program //
     ////////////////////////////////
-    
+
     wrapper.setProcessEnvironment(env);
     wrapper.setWorkingDirectory(OPENTRACK_BASE_PATH);
     wrapper.start(wine_path, { library_path + "opentrack-wrapper-wine.exe.so" });

--- a/proto-wine/ftnoir_protocol_wine.cpp
+++ b/proto-wine/ftnoir_protocol_wine.cpp
@@ -3,7 +3,6 @@
 #ifndef OTR_WINE_NO_WRAPPER
 #   include "csv/csv.h"
 #endif
-#include "compat/library-path.hpp"
 
 #include <cstring>
 #include <cmath>
@@ -121,7 +120,7 @@ module_status wine::initialize()
 
         if (s.proton_appid == 0)
             return error(tr("Must specify application id for Proton (Steam Play)"));
-        
+
         auto [prefix, error_string, success] = make_wineprefix(s.proton_appid);
         qDebug() << "proto/wine: wineprefix:" << prefix;
         env.insert("WINEPREFIX", prefix);

--- a/proto-wine/ftnoir_protocol_wine.cpp
+++ b/proto-wine/ftnoir_protocol_wine.cpp
@@ -1,4 +1,5 @@
 #include "ftnoir_protocol_wine.h"
+#include <qprocess.h>
 #ifndef OTR_WINE_NO_WRAPPER
 #   include "csv/csv.h"
 #endif
@@ -9,6 +10,8 @@
 
 #include <QString>
 #include <QDebug>
+
+#include "proton.h"
 
 wine::wine() = default;
 
@@ -63,50 +66,90 @@ module_status wine::initialize()
 #ifndef OTR_WINE_NO_WRAPPER
     static const QString library_path(OPENTRACK_BASE_PATH + OPENTRACK_LIBRARY_PATH);
 
+    /////////////////////////
+    // determine wine path //
+    /////////////////////////
     QString wine_path = "wine";
-    if (s.wine_select_path().toString() != "WINE") {
-        // if we are not supposed to use system wine then:
-        if (s.wine_select_path().toString() != "CUSTOM") {
-            // if we don't have a custom path then change the wine_path to the path corresponding to the selected version
-            wine_path = s.wine_select_path().toString();
-        }
-        else if (!s.wine_custom_path->isEmpty()) {
-            // if we do have a custom path and it is not empty then
-            wine_path = s.wine_custom_path;
-        }
-    }
-    if (wine_path[0] == '~')
-        wine_path = qgetenv("HOME") + wine_path.mid(1);
 
+    if (s.variant_wine) {
+        // NORMAL WINE
+
+        // resolve combo box
+        if (s.wine_select_path().toString() != "WINE") {
+            // if we are not supposed to use system wine then:
+            if (s.wine_select_path().toString() != "CUSTOM") {
+                // if we don't have a custom path then change the wine_path to the path corresponding to the selected version
+                wine_path = s.wine_select_path().toString();
+            }
+            else if (!s.wine_custom_path->isEmpty()) {
+                // if we do have a custom path and it is not empty then
+                wine_path = s.wine_custom_path;
+            }
+        }
+
+        // parse tilde if present
+        if (wine_path[0] == '~')
+            wine_path = qgetenv("HOME") + wine_path.mid(1);
+    }
+    else if (s.variant_proton)
+    {
+        // PROTON
+
+        wine_path = s.proton_path().toString() + "/bin/wine";
+    }
     qDebug() << "proto/wine: wine_path:" << wine_path;
 
-    auto env = QProcessEnvironment::systemEnvironment();
 
+    /////////////////////////////////////
+    // determine environment variables //
+    /////////////////////////////////////
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+
+    // if proton is used setup proton environment
     if (s.variant_proton)
     {
         if (s.proton_appid == 0)
             return error(tr("Must specify application id for Proton (Steam Play)"));
 
-        std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString& proton_dist_path, int appid);
-        QString proton_path(const QString& proton_dist_path);
-
-        QString proton_dist_path = s.proton_path().toString();
-
-        wine_path = proton_path(proton_dist_path);
-        auto [proton_env, error_string, success] = make_steam_environ(proton_dist_path, s.proton_appid);
+        auto [proton_env, env_error_string, env_success] = make_steam_environ(s.proton_path().toString());
         env = proton_env;
+
+        if (!env_success)
+            return error(env_error_string);
+    }
+
+    // determine wineprefix
+    if (s.variant_proton && s.variant_proton_steamplay) {
+        // wine prefix is dependend on steam
+
+        auto [prefix, error_string, success] = make_wineprefix(s.proton_appid);
+        env.insert("WINEPREFIX", prefix);
 
         if (!success)
             return error(error_string);
     }
-    else
-    {
-        QString wineprefix = "~/.wine";
-        if (!s.wineprefix->isEmpty())
+    else {
+        // wine prefix was supplied via path
+
+        QString wineprefix = "";
+
+        // check if prefix was supplied via wine
+        if (s.variant_wine && !s.wineprefix->isEmpty())
             wineprefix = s.wineprefix;
+
+        // check if prefix was supplied via proton
+        if (s.variant_proton_external && !s.protonprefix->isEmpty())
+            wineprefix = s.protonprefix;
+
+        // check if the user specified a prefix anywhere
+        if (wineprefix.isEmpty())
+            return error(tr("Prefix has not been defined!").arg(wineprefix));
+
+        // handle tilde
         if (wineprefix[0] == '~')
             wineprefix = qgetenv("HOME") + wineprefix.mid(1);
 
+        // return error if relative path is given
         if (wineprefix[0] != '/')
             return error(tr("Wine prefix must be an absolute path (given '%1')").arg(wineprefix));
 
@@ -115,13 +158,20 @@ module_status wine::initialize()
         env.insert("WINEPREFIX", wineprefix);
     }
 
+    // ESYNC and FSYNC
     if (s.esync)
         env.insert("WINEESYNC", "1");
     if (s.fsync)
         env.insert("WINEFSYNC", "1");
 
+    // Headtracking Protocol
     env.insert("OTR_WINE_PROTO", QString::number(s.protocol+1));
 
+
+    ////////////////////////////////
+    // launch the wrapper program //
+    ////////////////////////////////
+    
     wrapper.setProcessEnvironment(env);
     wrapper.setWorkingDirectory(OPENTRACK_BASE_PATH);
     wrapper.start(wine_path, { library_path + "opentrack-wrapper-wine.exe.so" });

--- a/proto-wine/ftnoir_protocol_wine.h
+++ b/proto-wine/ftnoir_protocol_wine.h
@@ -86,7 +86,9 @@ private slots:
     void onRadioButtonsChanged();
 
     void doBrowseWine();
-    void doBrowsePrefix();
+    void doBrowseWinePrefix();
+
+    void doBrowseProtonPrefix();
 
     void doOK();
     void doCancel();

--- a/proto-wine/ftnoir_protocol_wine.h
+++ b/proto-wine/ftnoir_protocol_wine.h
@@ -19,8 +19,10 @@ using namespace options;
 struct settings : opts
 {
     settings() : opts{"proto-wine"} {}
-    value<bool> variant_proton{b, "variant-proton", false },
-                variant_wine{b, "variant-wine", true },
+    value<bool> variant_wine{b, "variant-wine", true },
+                variant_proton{b, "variant-proton", false },
+                variant_proton_steamplay{b, "variant-proton-steamplay", true },
+                variant_proton_external{b, "variant-proton-external", false },
                 fsync{b, "fsync", true},
                 esync{b, "esync", true};
 
@@ -29,6 +31,7 @@ struct settings : opts
     value<QVariant> wine_select_path{b, "wine-select-version", {"WINE"}};
     value<QString> wine_custom_path{b, "wine-custom-version", ""};
     value<QString> wineprefix{b, "wineprefix", "~/.wine/"};
+    value<QString> protonprefix{b, "protonprefix", ""};
     value<int>     protocol{b, "protocol", 2};
 };
 
@@ -80,6 +83,7 @@ private:
 
 private slots:
     void onWinePathComboUpdated(QString selection);
+    void onRadioButtonsChanged();
 
     void doBrowseWine();
     void doBrowsePrefix();

--- a/proto-wine/ftnoir_protocol_wine.h
+++ b/proto-wine/ftnoir_protocol_wine.h
@@ -82,7 +82,7 @@ private:
     settings s;
 
 private slots:
-    void onWinePathComboUpdated(QString selection);
+    void onWinePathComboUpdated();
     void onRadioButtonsChanged();
 
     void doBrowseWine();

--- a/proto-wine/ftnoir_protocol_wine_dialog.cpp
+++ b/proto-wine/ftnoir_protocol_wine_dialog.cpp
@@ -92,7 +92,8 @@ FTControls::FTControls()
     // setup signals and slots for UI
     connect(ui.wine_path_combo, &QComboBox::currentTextChanged, this, &FTControls::onWinePathComboUpdated);
     connect(ui.browse_wine_path_button, &QPushButton::clicked, this, &FTControls::doBrowseWine);
-    connect(ui.browse_wine_prefix_button, &QPushButton::clicked, this, &FTControls::doBrowsePrefix);
+    connect(ui.browse_wine_prefix_button, &QPushButton::clicked, this, &FTControls::doBrowseWinePrefix);
+    connect(ui.browse_proton_prefix_button, &QPushButton::clicked, this, &FTControls::doBrowseProtonPrefix);
     connect(ui.buttonBox, &QDialogButtonBox::accepted, this, &FTControls::doOK);
     connect(ui.buttonBox, &QDialogButtonBox::rejected, this, &FTControls::doCancel);
 
@@ -104,6 +105,8 @@ FTControls::FTControls()
 
     // update state of the combo box and associated ui elements
     onWinePathComboUpdated(ui.wine_path_combo->currentText());
+    // hide the correct items
+    onRadioButtonsChanged();
 }
 
 void FTControls::onWinePathComboUpdated(QString selection) {
@@ -180,7 +183,7 @@ void FTControls::doBrowseWine() {
         s.wine_custom_path = d.selectedFiles()[0];
     }
 }
-void FTControls::doBrowsePrefix() {
+void FTControls::doBrowseWinePrefix() {
     QFileDialog d(this);
     d.setFileMode(QFileDialog::FileMode::Directory);
     d.setOption(QFileDialog::Option::ShowDirsOnly, true);
@@ -190,6 +193,19 @@ void FTControls::doBrowsePrefix() {
     }
     if (d.exec()) {
         s.wineprefix = d.selectedFiles()[0];
+    }
+}
+
+void FTControls::doBrowseProtonPrefix() {
+    QFileDialog d(this);
+    d.setFileMode(QFileDialog::FileMode::Directory);
+    d.setOption(QFileDialog::Option::ShowDirsOnly, true);
+    d.setWindowTitle(tr("Select Proton Prefix"));
+    if (s.protonprefix->startsWith("/") || s.protonprefix->startsWith("~")) {
+        d.selectFile(s.protonprefix);
+    }
+    if (d.exec()) {
+        s.protonprefix = d.selectedFiles()[0];
     }
 }
 

--- a/proto-wine/ftnoir_protocol_wine_dialog.cpp
+++ b/proto-wine/ftnoir_protocol_wine_dialog.cpp
@@ -72,7 +72,6 @@ FTControls::FTControls()
     }
 
     // settings - wine
-    // wine
     tie_setting(s.variant_wine, ui.variant_wine); // radio button
     tie_setting(s.wine_select_path, ui.wine_path_combo); // combo box (dropdown)
     tie_setting(s.wine_custom_path, ui.wine_path); // line edit (enabled via dropdown)
@@ -122,6 +121,9 @@ void FTControls::onWinePathComboUpdated(QString selection) {
 
 void FTControls::onRadioButtonsChanged() {
     if (ui.variant_wine->isChecked()) {
+        // wine settings selected
+
+        // enable wine settings
         ui.wine_path_combo->setEnabled(true);
         ui.wineprefix->setEnabled(true);
         ui.browse_wine_prefix_button->setEnabled(true);
@@ -130,27 +132,38 @@ void FTControls::onRadioButtonsChanged() {
             ui.browse_wine_path_button->setEnabled(true);
         }
 
+        // disable proton settings
         ui.proton_version->setEnabled(false);
         ui.proton_subgroup->setEnabled(false);
     }
     else if (ui.variant_proton->isChecked()) {
+        // proton settings selected
+
+        // disable wine settings
         ui.wine_path_combo->setEnabled(false);
         ui.wine_path->setEnabled(false);
+        ui.browse_wine_path_button->setEnabled(false);
         ui.wineprefix->setEnabled(false);
         ui.browse_wine_prefix_button->setEnabled(false);
 
+        // enable proton settings
         ui.proton_version->setEnabled(true);
         ui.proton_subgroup->setEnabled(true);
 
+        // run proton radio buttons logic
         if (ui.subvariant_steamplay->isChecked()) {
+            // enable steamplay settings
             ui.proton_appid->setEnabled(true);
 
+            // disable external settings
             ui.protonprefix->setEnabled(false);
             ui.browse_proton_prefix_button->setEnabled(false);
         }
         else if (ui.subvariant_external->isChecked()) {
+            // disable steamplay settings
             ui.proton_appid->setEnabled(false);
 
+            // enable external settinsg
             ui.protonprefix->setEnabled(true);
             ui.browse_proton_prefix_button->setEnabled(true);
         }

--- a/proto-wine/ftnoir_protocol_wine_dialog.cpp
+++ b/proto-wine/ftnoir_protocol_wine_dialog.cpp
@@ -20,10 +20,10 @@ static const char* wine_paths[][3] = {
     {"/.var/app/net.lutris.Lutris/data/lutris/runners/wine/", "/bin/wine", "Flatpak Lutris"}
 };
 
-static const char* proton_paths[] = {
-    "/.steam/steam/steamapps/common",
-    "/.steam/root/compatibilitytools.d",
-    "/.local/share/Steam/steamapps/common",
+static const char* proton_paths[][2] = {
+    {"/.steam/steam/steamapps/common", "Proton*"},
+    {"/.steam/root/compatibilitytools.d", "*"},
+    {"/.local/share/Steam/steamapps/common", "Proton*"},
 };
 
 FTControls::FTControls()
@@ -47,10 +47,10 @@ FTControls::FTControls()
     ui.wine_path_combo->addItem("Custom path to Wine executable", QVariant{"CUSTOM"});
 
     // populate proton select
-    for (const char* path : proton_paths) {
-        QDir dir(QDir::homePath() + path);
-        dir.setFilter(QDir::Dirs);
-        dir.setNameFilters({ "Proton*" });
+    for (const char** path : proton_paths) {
+        QDir dir(QDir::homePath() + path[0]);
+        dir.setFilter(QDir::Dirs | QDir::NoDotAndDotDot);
+        dir.setNameFilters({ path[1] });
 
         QFileInfoList proton_dir_list = dir.entryInfoList();
         for (int i = 0; i < proton_dir_list.size(); ++i) {

--- a/proto-wine/ftnoir_protocol_wine_dialog.cpp
+++ b/proto-wine/ftnoir_protocol_wine_dialog.cpp
@@ -3,6 +3,7 @@
 #include <QFileDialog>
 #include <QDir>
 #include <QDirIterator>
+#include <qcombobox.h>
 #include <qdebug.h>
 #include <qdir.h>
 #include <qradiobutton.h>
@@ -107,14 +108,14 @@ FTControls::FTControls()
     connect(ui.subvariant_external, &QRadioButton::clicked, this, &FTControls::onRadioButtonsChanged);
 
     // update state of the combo box and associated ui elements
-    onWinePathComboUpdated(ui.wine_path_combo->currentText());
+    onWinePathComboUpdated();
     // hide the correct items
     onRadioButtonsChanged();
 }
 
-void FTControls::onWinePathComboUpdated(QString selection) {
+void FTControls::onWinePathComboUpdated() {
     // enable the custom text field if required
-    if (selection == "Custom path to Wine executable") {
+    if (ui.wine_path_combo->currentData() == "CUSTOM") {
         ui.wine_path->setEnabled(true);
         ui.browse_wine_path_button->setEnabled(true);
     }
@@ -132,7 +133,7 @@ void FTControls::onRadioButtonsChanged() {
         ui.wine_path_combo->setEnabled(true);
         ui.wineprefix->setEnabled(true);
         ui.browse_wine_prefix_button->setEnabled(true);
-        if (ui.wine_path_combo->currentText() == "Custom path to Wine executable") {
+        if (ui.wine_path_combo->currentData() == "CUSTOM") {
             ui.wine_path->setEnabled(true);
             ui.browse_wine_path_button->setEnabled(true);
         }

--- a/proto-wine/ftnoir_protocol_wine_dialog.cpp
+++ b/proto-wine/ftnoir_protocol_wine_dialog.cpp
@@ -58,8 +58,7 @@ FTControls::FTControls()
             const QFileInfo &proton_dir = proton_dir_list.at(i);
 
             // check if this Proton Version is already present in any way
-            // NOTE: placed here instead of in front of the addItem call to improve performance
-            if (ui.proton_version->findData(QVariant{proton_dir.canonicalPath()}) != -1)
+            if (ui.proton_version->findText(proton_dir.fileName()) != -1)
                 continue;
 
             QDirIterator proton_executable_it(proton_dir.canonicalFilePath(), QStringList() << "wine", QDir::Files, QDirIterator::Subdirectories);

--- a/proto-wine/ftnoir_protocol_wine_dialog.cpp
+++ b/proto-wine/ftnoir_protocol_wine_dialog.cpp
@@ -57,6 +57,11 @@ FTControls::FTControls()
         for (int i = 0; i < proton_dir_list.size(); ++i) {
             const QFileInfo &proton_dir = proton_dir_list.at(i);
 
+            // check if this Proton Version is already present in any way
+            // NOTE: placed here instead of in front of the addItem call to improve performance
+            if (ui.proton_version->findData(QVariant{proton_dir.canonicalPath()}) != -1)
+                continue;
+
             QDirIterator proton_executable_it(proton_dir.canonicalFilePath(), QStringList() << "wine", QDir::Files, QDirIterator::Subdirectories);
 
             if (proton_executable_it.hasNext()) {
@@ -64,8 +69,7 @@ FTControls::FTControls()
                 QDir proton_dist_dir(proton_executable_path);
                 proton_dist_dir.cd("../../");
 
-                if (ui.proton_version->findData(QVariant{proton_dist_dir.canonicalPath()}) == -1)
-                    ui.proton_version->addItem(proton_dir.fileName(), QVariant{proton_dist_dir.canonicalPath()});
+                ui.proton_version->addItem(proton_dir.fileName(), QVariant{proton_dist_dir.canonicalPath()});
             }
         }
     }

--- a/proto-wine/ftnoir_protocol_wine_dialog.cpp
+++ b/proto-wine/ftnoir_protocol_wine_dialog.cpp
@@ -173,6 +173,12 @@ void FTControls::onRadioButtonsChanged() {
             ui.browse_proton_prefix_button->setEnabled(true);
         }
     }
+    else {
+        // for some reason QTs auto exclusive feature is not always correctly working
+        // this is a somewhat hacky solution
+        ui.variant_wine->setChecked(ui.wine_path_combo->isEnabled());
+        ui.variant_proton->setChecked(ui.proton_version->isEnabled());
+    }
 }
 
 void FTControls::doBrowseWine() {

--- a/proto-wine/ftnoir_protocol_wine_dialog.cpp
+++ b/proto-wine/ftnoir_protocol_wine_dialog.cpp
@@ -24,6 +24,7 @@ static const char* proton_paths[][2] = {
     {"/.steam/steam/steamapps/common", "Proton*"},
     {"/.steam/root/compatibilitytools.d", "*"},
     {"/.local/share/Steam/steamapps/common", "Proton*"},
+    {"/.local/share/Steam/compatibilitytools.d", "*"},
 };
 
 FTControls::FTControls()
@@ -55,7 +56,6 @@ FTControls::FTControls()
         QFileInfoList proton_dir_list = dir.entryInfoList();
         for (int i = 0; i < proton_dir_list.size(); ++i) {
             const QFileInfo &proton_dir = proton_dir_list.at(i);
-            qDebug() << proton_dir.canonicalFilePath();
 
             QDirIterator proton_executable_it(proton_dir.canonicalFilePath(), QStringList() << "wine", QDir::Files, QDirIterator::Subdirectories);
 
@@ -64,9 +64,8 @@ FTControls::FTControls()
                 QDir proton_dist_dir(proton_executable_path);
                 proton_dist_dir.cd("../../");
 
-                qDebug() << proton_dist_dir.canonicalPath();
-
-                ui.proton_version->addItem(proton_dir.fileName(), QVariant{proton_dist_dir.canonicalPath()});
+                if (ui.proton_version->findData(QVariant{proton_dist_dir.canonicalPath()}) == -1)
+                    ui.proton_version->addItem(proton_dir.fileName(), QVariant{proton_dist_dir.canonicalPath()});
             }
         }
     }

--- a/proto-wine/ftnoir_winecontrols.ui
+++ b/proto-wine/ftnoir_winecontrols.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>951</width>
-    <height>424</height>
+    <width>955</width>
+    <height>468</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,86 +32,8 @@
      <property name="title">
       <string>Wine variant</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="10" column="0">
-       <widget class="QRadioButton" name="variant_proton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Proton (Steam Play)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="variant_wine">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Wine (select path and prefix)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="10" column="1">
-       <widget class="QComboBox" name="proton_version">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>120</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QLineEdit" name="wineprefix">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>450</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;prefix&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="placeholderText">
-           <string>/path_to_the_prefix/</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="browse_wine_prefix_button">
-          <property name="text">
-           <string>Browse Prefix</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="8" column="1">
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QLineEdit" name="wine_path">
@@ -146,6 +68,12 @@
           <property name="enabled">
            <bool>false</bool>
           </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="text">
            <string>Browse Wine Path</string>
           </property>
@@ -153,8 +81,169 @@
         </item>
        </layout>
       </item>
+      <item row="2" column="1">
+       <layout class="QVBoxLayout" name="verticalLayout_7">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
+           <widget class="QLineEdit" name="wineprefix">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>450</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;prefix&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="placeholderText">
+             <string>/path_to_the_prefix/</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="browse_wine_prefix_button">
+            <property name="text">
+             <string>Browse Prefix</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="proton_version">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QRadioButton" name="variant_proton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Proton (select version and mode)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="variant_wine">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Wine (select version and prefix)</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="wine_path_combo"/>
+       <widget class="QComboBox" name="wine_path_combo">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QGroupBox" name="verticalGroupBox_3">
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="proton_appid">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximum">
+            <number>2147483647</number>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QRadioButton" name="subvariant_steamplay">
+           <property name="text">
+            <string>Steam Play (select Steam Application ID)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QRadioButton" name="subvariant_umu">
+           <property name="text">
+            <string>UMU enabled Launchers (select prefix)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <item>
+            <widget class="QLineEdit" name="protonprefix">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>450</width>
+               <height>0</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="browse_proton_path_button">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>105</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Browse Prefix</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -271,32 +360,6 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Steam application id</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="proton_appid">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximum">
-            <number>2147483647</number>
-           </property>
-          </widget>
-         </item>
         </layout>
        </widget>
       </item>

--- a/proto-wine/ftnoir_winecontrols.ui
+++ b/proto-wine/ftnoir_winecontrols.ui
@@ -197,6 +197,9 @@
          </item>
          <item row="0" column="0">
           <widget class="QRadioButton" name="subvariant_steamplay">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Steam Play is Steams System to run Windows titles on Linux via Proton.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
            <property name="text">
             <string>Steam Play (select Steam Application ID)</string>
            </property>
@@ -204,6 +207,9 @@
          </item>
          <item row="1" column="0">
           <widget class="QRadioButton" name="subvariant_external">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;UMU is a launcher that allows the use of Proton outside of Steam. Some game launchers like Lutris may use this to enable Proton support.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
            <property name="text">
             <string>UMU enabled Launchers (select prefix)</string>
            </property>

--- a/proto-wine/ftnoir_winecontrols.ui
+++ b/proto-wine/ftnoir_winecontrols.ui
@@ -120,6 +120,9 @@
       </item>
       <item row="3" column="1">
        <widget class="QComboBox" name="proton_version">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -174,7 +177,10 @@
        </widget>
       </item>
       <item row="4" column="0" colspan="2">
-       <widget class="QGroupBox" name="verticalGroupBox_3">
+       <widget class="QGroupBox" name="proton_subgroup">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <layout class="QGridLayout" name="gridLayout">
          <item row="0" column="1">
           <widget class="QSpinBox" name="proton_appid">
@@ -197,7 +203,7 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QRadioButton" name="subvariant_umu">
+          <widget class="QRadioButton" name="subvariant_external">
            <property name="text">
             <string>UMU enabled Launchers (select prefix)</string>
            </property>
@@ -222,7 +228,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="browse_proton_path_button">
+            <widget class="QPushButton" name="browse_proton_prefix_button">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>

--- a/proto-wine/ftnoir_winecontrols.ui
+++ b/proto-wine/ftnoir_winecontrols.ui
@@ -120,9 +120,6 @@
       </item>
       <item row="3" column="1">
        <widget class="QComboBox" name="proton_version">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -178,9 +175,6 @@
       </item>
       <item row="4" column="0" colspan="2">
        <widget class="QGroupBox" name="proton_subgroup">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
         <layout class="QGridLayout" name="gridLayout">
          <item row="0" column="1">
           <widget class="QSpinBox" name="proton_appid">

--- a/proto-wine/ftnoir_winecontrols.ui
+++ b/proto-wine/ftnoir_winecontrols.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>955</width>
-    <height>468</height>
+    <width>934</width>
+    <height>466</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -387,6 +387,24 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>variant_wine</tabstop>
+  <tabstop>wine_path_combo</tabstop>
+  <tabstop>wine_path</tabstop>
+  <tabstop>browse_wine_path_button</tabstop>
+  <tabstop>wineprefix</tabstop>
+  <tabstop>browse_wine_prefix_button</tabstop>
+  <tabstop>variant_proton</tabstop>
+  <tabstop>proton_version</tabstop>
+  <tabstop>subvariant_steamplay</tabstop>
+  <tabstop>proton_appid</tabstop>
+  <tabstop>subvariant_external</tabstop>
+  <tabstop>protonprefix</tabstop>
+  <tabstop>browse_proton_prefix_button</tabstop>
+  <tabstop>esync</tabstop>
+  <tabstop>fsync</tabstop>
+  <tabstop>protocol_selection</tabstop>
+ </tabstops>
  <resources>
   <include location="wine-protocol.qrc"/>
  </resources>

--- a/proto-wine/lang/de_DE.ts
+++ b/proto-wine/lang/de_DE.ts
@@ -90,6 +90,14 @@
         <source>Wine (select version and prefix)</source>
         <translation>Wine (wähle Version und Prefix)</translation>
     </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Steam Play is Steams System to run Windows titles on Linux via Proton.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Steam Play ist Steams System, um Windows Titel auf Linux, via Proton, auszuführen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;UMU is a launcher that allows the use of Proton outside of Steam. Some game launchers like Lutris may use this to enable Proton support.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;UMU ist ein Launcher, der es erlaubt Proton außerhalb von Steam zu nutzen. Manche Spiel Launcher, wie Lutris, können dies für Proton Support nutzen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
 </context>
 <context>
     <name>wine</name>

--- a/proto-wine/lang/de_DE.ts
+++ b/proto-wine/lang/de_DE.ts
@@ -121,6 +121,10 @@
         <source>Can&apos;t open shared memory mapping</source>
         <translation>Shared-Memory-Mapping kann nicht geöffnet werden</translation>
     </message>
+    <message>
+        <source>Prefix has not been defined!</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>wine_metadata</name>

--- a/proto-wine/lang/de_DE.ts
+++ b/proto-wine/lang/de_DE.ts
@@ -11,6 +11,10 @@
         <source>Select Wine Prefix</source>
         <translation>wine-Prefix auswählen</translation>
     </message>
+    <message>
+        <source>Select Proton Prefix</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UICFTControls</name>

--- a/proto-wine/lang/de_DE.ts
+++ b/proto-wine/lang/de_DE.ts
@@ -23,14 +23,6 @@
         <translation>Wine-Variante</translation>
     </message>
     <message>
-        <source>Proton (Steam Play)</source>
-        <translation>Proton (Steam Play)</translation>
-    </message>
-    <message>
-        <source>Wine (select path and prefix)</source>
-        <translation>Wine (Pfad und Prefix auswählen)</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;prefix&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prefix&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -83,8 +75,20 @@
         <translation>Beides</translation>
     </message>
     <message>
-        <source>Steam application id</source>
-        <translation>Steam-Application-ID</translation>
+        <source>Proton (select version and mode)</source>
+        <translation>Proton (wähle Version und Modus)</translation>
+    </message>
+    <message>
+        <source>Steam Play (select Steam Application ID)</source>
+        <translation>Steam Play (wähle Steam Applikation ID)</translation>
+    </message>
+    <message>
+        <source>UMU enabled Launchers (select prefix)</source>
+        <translation>UMU unterstützte Launcher (wähle Prefix)</translation>
+    </message>
+    <message>
+        <source>Wine (select version and prefix)</source>
+        <translation>Wine (wähle Version und Prefix)</translation>
     </message>
 </context>
 <context>

--- a/proto-wine/lang/nl_NL.ts
+++ b/proto-wine/lang/nl_NL.ts
@@ -11,6 +11,10 @@
         <source>Select Wine Prefix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select Proton Prefix</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UICFTControls</name>

--- a/proto-wine/lang/nl_NL.ts
+++ b/proto-wine/lang/nl_NL.ts
@@ -90,6 +90,14 @@
         <source>Wine (select version and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Steam Play is Steams System to run Windows titles on Linux via Proton.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;UMU is a launcher that allows the use of Proton outside of Steam. Some game launchers like Lutris may use this to enable Proton support.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>wine</name>

--- a/proto-wine/lang/nl_NL.ts
+++ b/proto-wine/lang/nl_NL.ts
@@ -39,14 +39,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Steam application id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Proton (Steam Play)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,10 +52,6 @@
     </message>
     <message>
         <source>Both</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wine (select path and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -84,6 +72,22 @@
     </message>
     <message>
         <source>Browse Wine Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proton (select version and mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Steam Play (select Steam Application ID)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UMU enabled Launchers (select prefix)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wine (select version and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/proto-wine/lang/nl_NL.ts
+++ b/proto-wine/lang/nl_NL.ts
@@ -121,6 +121,10 @@
         <source>Failed to start Wine! Make sure the binary is set correctly.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Prefix has not been defined!</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>wine_metadata</name>

--- a/proto-wine/lang/ru_RU.ts
+++ b/proto-wine/lang/ru_RU.ts
@@ -11,6 +11,10 @@
         <source>Select Wine Prefix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select Proton Prefix</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UICFTControls</name>

--- a/proto-wine/lang/ru_RU.ts
+++ b/proto-wine/lang/ru_RU.ts
@@ -90,6 +90,14 @@
         <source>Wine (select version and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Steam Play is Steams System to run Windows titles on Linux via Proton.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;UMU is a launcher that allows the use of Proton outside of Steam. Some game launchers like Lutris may use this to enable Proton support.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>wine</name>

--- a/proto-wine/lang/ru_RU.ts
+++ b/proto-wine/lang/ru_RU.ts
@@ -39,14 +39,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Steam application id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Proton (Steam Play)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,10 +52,6 @@
     </message>
     <message>
         <source>Both</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wine (select path and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -84,6 +72,22 @@
     </message>
     <message>
         <source>Browse Wine Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proton (select version and mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Steam Play (select Steam Application ID)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UMU enabled Launchers (select prefix)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wine (select version and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/proto-wine/lang/ru_RU.ts
+++ b/proto-wine/lang/ru_RU.ts
@@ -121,6 +121,10 @@
         <source>Failed to start Wine! Make sure the binary is set correctly.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Prefix has not been defined!</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>wine_metadata</name>

--- a/proto-wine/lang/stub.ts
+++ b/proto-wine/lang/stub.ts
@@ -11,6 +11,10 @@
         <source>Select Wine Prefix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select Proton Prefix</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UICFTControls</name>

--- a/proto-wine/lang/stub.ts
+++ b/proto-wine/lang/stub.ts
@@ -90,6 +90,14 @@
         <source>Wine (select version and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Steam Play is Steams System to run Windows titles on Linux via Proton.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;UMU is a launcher that allows the use of Proton outside of Steam. Some game launchers like Lutris may use this to enable Proton support.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>wine</name>

--- a/proto-wine/lang/stub.ts
+++ b/proto-wine/lang/stub.ts
@@ -39,14 +39,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Steam application id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Proton (Steam Play)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,10 +52,6 @@
     </message>
     <message>
         <source>Both</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wine (select path and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -84,6 +72,22 @@
     </message>
     <message>
         <source>Browse Wine Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proton (select version and mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Steam Play (select Steam Application ID)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UMU enabled Launchers (select prefix)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wine (select version and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/proto-wine/lang/stub.ts
+++ b/proto-wine/lang/stub.ts
@@ -121,6 +121,10 @@
         <source>Failed to start Wine! Make sure the binary is set correctly.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Prefix has not been defined!</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>wine_metadata</name>

--- a/proto-wine/lang/zh_CN.ts
+++ b/proto-wine/lang/zh_CN.ts
@@ -11,6 +11,10 @@
         <source>Select Wine Prefix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select Proton Prefix</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UICFTControls</name>

--- a/proto-wine/lang/zh_CN.ts
+++ b/proto-wine/lang/zh_CN.ts
@@ -90,6 +90,14 @@
         <source>Wine (select version and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Steam Play is Steams System to run Windows titles on Linux via Proton.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;UMU is a launcher that allows the use of Proton outside of Steam. Some game launchers like Lutris may use this to enable Proton support.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>wine</name>

--- a/proto-wine/lang/zh_CN.ts
+++ b/proto-wine/lang/zh_CN.ts
@@ -39,14 +39,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Steam application id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Proton (Steam Play)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,10 +52,6 @@
     </message>
     <message>
         <source>Both</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wine (select path and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -84,6 +72,22 @@
     </message>
     <message>
         <source>Browse Wine Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proton (select version and mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Steam Play (select Steam Application ID)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UMU enabled Launchers (select prefix)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wine (select version and prefix)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/proto-wine/lang/zh_CN.ts
+++ b/proto-wine/lang/zh_CN.ts
@@ -121,6 +121,10 @@
         <source>Failed to start Wine! Make sure the binary is set correctly.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Prefix has not been defined!</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>wine_metadata</name>

--- a/proto-wine/proton.cpp
+++ b/proto-wine/proton.cpp
@@ -10,9 +10,9 @@
 #include <QDebug>
 #include <QDir>
 #include <QFileInfo>
-#include <QProcessEnvironment>
 #include <QtGlobal>
 
+#include "proton.h"
 
 static const char* steam_paths[] = {
     "/.steam/steam/steamapps/compatdata",
@@ -27,13 +27,13 @@ static const char* runtime_paths[] = {
 };
 
 
-std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString& proton_dist_path, int appid)
+std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString& proton_dist_path)
 {
     using ret = std::tuple<QProcessEnvironment, QString, bool>;
     auto env = QProcessEnvironment::systemEnvironment();
     QString error = "";
     QString home = qgetenv("HOME");
-    QString runtime_path, app_wineprefix;
+    QString runtime_path;
 
     auto expand = [&](QString x) {
                       x.replace("HOME", home);
@@ -50,14 +50,6 @@ std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString&
 
     if (runtime_path.isEmpty())
         error = QString("Couldn't find a Steam runtime.");
-
-    for (const char* path : steam_paths) {
-        QDir dir(QDir::homePath() + path + expand("/%1/pfx").arg(appid));
-        if (dir.exists())
-            app_wineprefix = dir.absolutePath();
-    }
-    if (app_wineprefix.isEmpty())
-        error = QString("Couldn't find a Wineprefix for AppId %1").arg(appid);
 
     QString path = expand(
         ":PROTON_DIST_PATH/bin"
@@ -81,14 +73,25 @@ std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString&
     );
     library_path += ':'; library_path += qgetenv("LD_LIBRARY_PATH");
     env.insert("LD_LIBRARY_PATH", library_path);
-    env.insert("WINEPREFIX", app_wineprefix);
 
     return ret(env, error, error.isEmpty());
 }
 
 
-QString proton_path(const QString& proton_dist_path)
+std::tuple<QString, QString, bool> make_wineprefix(int appid)
 {
-    return proton_dist_path + "/bin/wine";
+    using ret = std::tuple<QString, QString, bool>;
+    QString error = "";
+    QString app_wineprefix;
+    for (const char* path : steam_paths) {
+        QDir dir(QDir::homePath() + path + QString("/%1/pfx").arg(appid));
+        if (dir.exists())
+            app_wineprefix = dir.absolutePath();
+    }
+    if (app_wineprefix.isEmpty())
+        error = QString("Couldn't find a Wineprefix for AppId %1").arg(appid);
+
+    return ret(app_wineprefix, error, error.isEmpty());
 }
+
 #endif

--- a/proto-wine/proton.h
+++ b/proto-wine/proton.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <qchar.h>
+#include <qprocess.h>
+
+std::tuple<QProcessEnvironment, QString, bool> make_steam_environ(const QString& proton_dist_path);
+std::tuple<QString, QString, bool> make_wineprefix(int appid);


### PR DESCRIPTION
RFC: #1923 

### Problem
The proto-wine module has Proton support but it only allows Proton to be used within Steam. With the introduction of UMU and the shift of GloriousEggroll towards Proton the current feature support may no longer be adequate.

### Solution provided by this PR
The UI has been changed to allow the user to specify a Proton Prefix or keep on utilizing the already existing Steam Application ID mechanism.
Elements that are not in use or relevant to the current functionality are also now being disabled.

![Screenshot_20240921_011346](https://github.com/user-attachments/assets/463d59bc-5615-4be7-85f3-9eac7940f4a8)

Additionally the `make_steam_environ(proton_path, appid)` function has been split up into `make_steam_environ(proton_path)` and `make_wineprefix(appid)` to continue using the steam environment independently from the appid.

The `wine::initialize()` function has been refactored to make use of the above changes and add comments explaining every step.

### Change Summary
- Redesigned the wine UI to allow for specifying custom Proton Prefixes and improve UX
  - The user is promted to select either the Wine or Proton environment (disabling the UI components of the other)
  - If Proton is chosen the user further needs to specify is Proton is used within Steam or externally (likely through UMU). Tooltips are present to explain what each option does. (This also features the disabling of UI components.)
- Refactored protocol code to allow for the use of Proton outside of Steam
- Fixed an issue where Proton Versions may appear multiple times
- Fixed an issue where some 3rd party Proton Versions were not getting detected
