### PR TITLE
tracker/nn: Update models

### DIFF
--- a/tracker-neuralnet/CMakeLists.txt
+++ b/tracker-neuralnet/CMakeLists.txt
@@ -33,9 +33,9 @@ if(OpenCV_FOUND AND ONNXRuntime_FOUND AND OpenMP_FOUND)
 
     install(
         FILES "models/head-localizer.onnx" 
-              "models/head-pose.onnx"
               "models/head-pose-0.2-big.onnx"
               "models/head-pose-0.2-small.onnx"
+              "models/head-pose-0.3-big-quantized.onnx"
         DESTINATION "${opentrack-libexec}/models"
         PERMISSIONS ${opentrack-perms-file}
         )

--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.h
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.h
@@ -84,7 +84,7 @@ struct Settings : opts {
     value<int> resolution { b, "force-resolution", 0 };
     value<double> deadzone_size { b, "deadzone-size", 1. };
     value<double> deadzone_hardness { b, "deadzone-hardness", 1.5 };
-    value<QString> posenet_file { b, "posenet-file", "head-pose.onnx" };
+    value<QString> posenet_file { b, "posenet-file", "head-pose-0.3-big-quantized.onnx" };
     Settings();
 };
 


### PR DESCRIPTION
Hi @sthalik 

I think it is time to update the neuralnet models.  :-)

For one I removed `head-pose.onnx`. I think the newer models are better. Personally I don't use it any more.

Then I added `head-pose-0.3-big-quantized.onnx`. It is the same architecture as `head-pose-0.2`. Performance in terms of accuracy should be very similar. However this one was "quantized" after training, i.e. the convolution ops were converted so they use integer computations. On my machine this reduces inference time to 70% of the float32 model with negligible accuracy loss.

The mobilenet variant suffered quite a big hit which is why only the big model is updated.

I left `head-pose-0.2` in place because I don't know if the quantized model has universally better performance on all hardware. To get some user experiences would be interesting.

(New model trained with latest https://github.com/opentrack/neuralnet-tracker-traincode commit 9891d60)