### PR TITLE
tracker/nn: Add more fps options

### DIFF
--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
@@ -66,13 +66,26 @@ QDir get_default_model_directory()
 
 int enum_to_fps(int value)
 {
+    int fps = 0;
+
     switch (value)
     {
-        case fps_30:        return 30;
-        case fps_60:        return 60;
-        default: [[fallthrough]];
-        case fps_default:   return 0;
+    default: eval_once(qDebug() << "neuralnet tracker: invalid fps enum value");
+    [[fallthrough]];
+    case fps_default:   fps = 0; break;
+    case fps_30:        fps = 30; break;
+    case fps_60:        fps = 60; break;
+    case fps_75:        fps = 75; break;
+    case fps_125:       fps = 125; break;
+    case fps_200:       fps = 200; break;
+    case fps_50:        fps = 50; break;
+    case fps_100:       fps = 100; break;
+    case fps_120:       fps = 120; break;
+    case fps_300:       fps = 300; break;
+    case fps_250:       fps = 250; break;
     }
+
+    return fps;
 }
 
 
@@ -414,7 +427,7 @@ QuatPose NeuralNetTracker::transform_to_world_pose(const cv::Quatf &face_rotatio
 
 QuatPose NeuralNetTracker::compute_filtered_pose(const PoseEstimator::Face &face)
 {
-    if (fps_ > 0.01 && last_pose_ && poseestimator_->has_uncertainty())
+    if (fps_ > 0.001 && last_pose_ && poseestimator_->has_uncertainty())
     {
         auto image2world = [this](const cv::Quatf &face_rotation, const cv::Point2f& face_xy, const float face_size) {
                 return this->transform_to_world_pose(face_rotation, face_xy, face_size); };
@@ -705,14 +718,6 @@ QString NeuralNetTracker::get_posenet_filename() const
         filename = get_default_model_directory().absoluteFilePath(filename);
     return filename;
 }
-
-
-
-
-
-
-
-
 
 
 void NeuralNetDialog::make_fps_combobox()

--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.h
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.h
@@ -48,7 +48,15 @@ enum fps_choices
     fps_default = 0,
     fps_30      = 1,
     fps_60      = 2,
-    fps_MAX     = 3
+    fps_75      = 3,
+    fps_125     = 4,
+    fps_200     = 5,
+    fps_50      = 6,
+    fps_100     = 7,
+    fps_120     = 8,
+    fps_300     = 9,
+    fps_250     = 10,
+    fps_MAX     = 11,
 };
 
 struct resolution_tuple


### PR DESCRIPTION
This PR is an attempt to add more FPS options to the neuralnet tracker.

@sthalik , or anyone, is this all I need to change?
I check that the fps is passed to your `camera::start`. That's okay.
But on linux my (cheap) webcam was still fixed at 30 fps and the trackhat cam at 60 fps. Need to check on windows.