### PR TITLE
Give evdev arbitrary bustype vendor product and version ids

### DIFF
--- a/proto-libevdev/ftnoir_protocol_libevdev.cpp
+++ b/proto-libevdev/ftnoir_protocol_libevdev.cpp
@@ -55,6 +55,11 @@ evdev::evdev()
     CHECK_LIBEVDEV(libevdev_enable_property(dev, INPUT_PROP_BUTTONPAD));
 
     libevdev_set_name(dev, "opentrack headpose");
+    
+    libevdev_set_id_bustype(dev, 3);
+    libevdev_set_id_vendor(dev, 4324);
+    libevdev_set_id_product(dev, 3798);
+    libevdev_set_id_version(dev, 123);
 
     struct input_absinfo absinfo;
 


### PR DESCRIPTION
This fixes Euro Truck Simulator 2 on linux not detecting the libevdev joystick receiver.