### PR TITLE
Update CMake workflow for Ubuntu 22.04 and ONNXRuntime integration

### DIFF
--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -2,8 +2,7 @@ name: Linuax Package
 on:
   push:
     tags:
-      - 'opentrack-[0-9]+.[0-9]+.[0-9]+'
-      - 'opentrack-[0-9]+.[0-9]+.[0-9]+-[a-zA-z0-9]+'
+      - 'opentrack-*'
   workflow_dispatch:
 env:
   build_type: Release
@@ -63,7 +62,7 @@ jobs:
         echo '"$CURRENT_PATH/bin/opentrack" "$@"' >> opentrack
         chmod +x opentrack
 
-        if [[ ${{github.ref_name}} =~ ^opentrack-\d+\.\d+\.\d+$ ]]; then
+        if [[ ${{github.ref_name}} =~ ^opentrack.*$ ]]; then
           file_name=${{github.ref_name}}-linux.tar.gz
         else
           file_name=opentrack-dev-linux.tar.gz


### PR DESCRIPTION
I saw the current CI pipeline does not use a consistent Qt installation and does not pack the binary, I try to improve the workflow in this PR.