### PR TITLE
tracker/neuralnet: revert construction of Ort::Env mostly

### DIFF
--- a/tracker-neuralnet/CMakeLists.txt
+++ b/tracker-neuralnet/CMakeLists.txt
@@ -3,9 +3,8 @@ set(host-spec "${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR} ${CMAKE_SIZEOF_VOI
 if(host-spec MATCHES "^Linux i[3-6]86 4$")
     return()
 endif()
-if(NOT DEFINED opentrack-use-onnxruntime-avx-dispatch)
-    set(opentrack-use-onnxruntime-avx-dispatch 0)
-endif()
+
+set(opentrack-use-onnxruntime-avx-dispatch False CACHE BOOL "Enable dynamic loading and dispatching to avx-enabled onnxruntime")
 
 find_package(OpenCV QUIET)
 find_package(OpenMP QUIET) # Used to control number of onnx threads.

--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
@@ -490,9 +490,15 @@ bool NeuralNetTracker::load_and_initialize_model()
         OPENTRACK_BASE_PATH+"/" OPENTRACK_LIBRARY_PATH "/models/head-localizer.onnx";
     const QString poseestimator_model_path_enc = get_posenet_filename();
 
+    maybe_load_onnxruntime_dynamically();
+
     try
     {
-        env_ = make_ort_env();
+        env_ = Ort::Env {
+            OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+            "tracker-neuralnet"
+        };
+
         auto opts = Ort::SessionOptions{};
         // Do thread settings here do anything?
         // There is a warning which says to control number of threads via

--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.h
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.h
@@ -127,7 +127,7 @@ private:
     bool open_camera();
     void set_intrinsics();
     cv::Mat prepare_input_image(const video::frame& frame);
-    static Ort::Env make_ort_env();
+    static void maybe_load_onnxruntime_dynamically();
     bool load_and_initialize_model();
     void draw_gizmos(
         const std::optional<PoseEstimator::Face> &face,


### PR DESCRIPTION
Hi @sthalik , 

like so?

As far as I can tell, the change to `Ort::Env` wasn't needed. This PR works for me, too. Ort::Env uses `Ort::Global<void>::api_` internally, so it doesn't need special treatment over the other c++ classes which do the same.