### PR TITLE
Change libevdev id vendor and id product to arbitrary unique values. Fixes Euro Truck Sim 2

### DIFF
--- a/proto-libevdev/ftnoir_protocol_libevdev.cpp
+++ b/proto-libevdev/ftnoir_protocol_libevdev.cpp
@@ -55,8 +55,8 @@ evdev::evdev()
     CHECK_LIBEVDEV(libevdev_enable_property(dev, INPUT_PROP_BUTTONPAD));
 
     libevdev_set_name(dev, "opentrack headpose");
-    libevdev_set_id_vendor(dev, 1);
-    libevdev_set_id_product(dev, 1);
+    libevdev_set_id_vendor(dev, 1964);
+    libevdev_set_id_product(dev, 9526);
     libevdev_set_id_bustype(dev, 3);
     libevdev_set_id_version(dev, 123);
 


### PR DESCRIPTION
This commit https://github.com/opentrack/opentrack/commit/839965556f91dceab7c3d8ef5a90760d7c911859 made it so Euro Truck Sim 2 no longer detects opentrack.

This pull request changes the vendor id and product id to values that should be unique. 