### PR TITLE
feat: add SmoothTrack iOS head tracker plugin

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,11 +48,17 @@ jobs:
         sudo apt install libproc2-dev libopencv-dev libopencv-dev wine64-tools
         sudo apt install qt6-tools-dev qt6-serialport-dev qt6-base-private-dev
         sudo apt install libusb-1.0-0-dev libsdl2-dev
+        sudo apt-get install libusbmuxd-dev
 
         mkdir /tmp/a
         wget -qO- https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-linux-x64-1.23.2.tgz  | tar --strip-components=1 -zxf - -C/tmp/a
         sudo cp -R /tmp/a/{lib,include} /usr
       if: matrix.os == 'ubuntu-latest'
+
+    - name: Install dependencies (Windows)
+      run: |
+        vcpkg install libusbmuxd:x64-windows
+      if: matrix.os == 'windows-latest'
 
     - name: Install opencv (Windows)
       uses: cvpkg/opencv-action@main
@@ -64,7 +70,7 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: Install opencv (macOS)
-      run: brew install opencv
+      run: brew install opencv libusbmuxd
       if: matrix.os == 'macos-latest'
 
     - name: Install Qt
@@ -77,8 +83,13 @@ jobs:
         #use-official: true
       if: matrix.os != 'ubuntu-latest'
 
-    - name: Configure
+    - name: Configure (Windows)
+      run: ${{matrix.cmake}} -GNinja -S ${{github.workspace}}/ -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DQt6_DIR="${{env.QT_ROOT_DIR}}/lib/cmake/Qt6" -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+      if: matrix.os == 'windows-latest'
+
+    - name: Configure (Unix)
       run: ${{matrix.cmake}} -GNinja -S ${{github.workspace}}/ -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DQt6_DIR="${{env.QT_ROOT_DIR}}/lib/cmake/Qt6" -DONNXRuntime_DIR=/usr/lib/cmake/onnxruntime
+      if: matrix.os != 'windows-latest'
 
     - name: Build
       run: ${{matrix.cmake}} --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target install

--- a/tracker-smoothtrack/CMakeLists.txt
+++ b/tracker-smoothtrack/CMakeLists.txt
@@ -1,0 +1,29 @@
+# vcpkg ships libusbmuxd with a CMake config package (Windows), while distro
+# and Homebrew packages only ship pkg-config metadata. Try both, and skip the
+# module rather than failing configure when neither is present.
+find_package(unofficial-libusbmuxd CONFIG QUIET)
+
+if(unofficial-libusbmuxd_FOUND)
+    otr_module(tracker-smoothtrack)
+    target_link_libraries(${self} PRIVATE unofficial::libusbmuxd::libusbmuxd)
+    if(WIN32)
+        otr_install_lib(unofficial::libusbmuxd::libusbmuxd "${opentrack-libexec}")
+        # libusbmuxd pulls in libplist and libimobiledevice-glue. The vcpkg
+        # toolchain copies those next to the build output but not into the
+        # install tree, so the installed plugin would fail to load. This walks
+        # the installed binary's imports and copies what it actually needs.
+        # Must come after otr_module(), whose install() rule it runs behind.
+        if(COMMAND x_vcpkg_install_local_dependencies)
+            x_vcpkg_install_local_dependencies(TARGETS ${self} DESTINATION "${opentrack-libexec}")
+        endif()
+    endif()
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(USBMUXD IMPORTED_TARGET libusbmuxd-2.0)
+    endif()
+    if(USBMUXD_FOUND)
+        otr_module(tracker-smoothtrack)
+        target_link_libraries(${self} PRIVATE PkgConfig::USBMUXD)
+    endif()
+endif()

--- a/tracker-smoothtrack/ftnoir_tracker_smoothtrack.cpp
+++ b/tracker-smoothtrack/ftnoir_tracker_smoothtrack.cpp
@@ -1,0 +1,199 @@
+/* Copyright (c) 2025
+ *
+ * Permission to use, copy, modify, and/or distribute this
+ * software for any purpose with or without fee is hereby granted,
+ * provided that the above copyright notice and this permission
+ * notice appear in all copies.
+ */
+
+#include "ftnoir_tracker_smoothtrack.h"
+#include "api/plugin-api.hpp"
+
+#include <QSocketNotifier>
+#include <cmath>
+#include <iterator>
+
+#ifdef _WIN32
+#   include <winsock2.h>
+#else
+#   include <unistd.h>
+#endif
+
+smoothtrack::smoothtrack() : last_recv_pose{ 0, 0, 0, 0, 0, 0 }, last_recv_pose2{ 0, 0, 0, 0, 0, 0 }
+{
+}
+
+smoothtrack::~smoothtrack()
+{
+    requestInterruption();
+    wait();
+    disconnect_from_device();
+}
+
+bool smoothtrack::connect_to_device()
+{
+    // Try to connect to iOS device via usbmuxd
+    usbmuxd_device_info_t* device_list = nullptr;
+    int device_count = usbmuxd_get_device_list(&device_list);
+
+    if (device_count < 1)
+    {
+        if (device_list)
+            usbmuxd_device_list_free(&device_list);
+        return false;
+    }
+
+    // Use the first available device
+    uint32_t device_handle = device_list[0].handle;
+    usbmuxd_device_list_free(&device_list);
+
+    // Connect to the SmoothTrack port on the iOS device
+    usbmuxd_fd = usbmuxd_connect(device_handle, static_cast<uint16_t>(s.port));
+
+    if (usbmuxd_fd < 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void smoothtrack::disconnect_from_device()
+{
+    if (sock)
+    {
+        // setSocketDescriptor() handed usbmuxd_fd over to Qt, so closing the
+        // socket closes the descriptor too. Closing it again here would be a
+        // double close, and could take out an unrelated fd opened meanwhile.
+        sock->close();
+        sock->deleteLater();
+        sock = nullptr;
+    }
+    else if (usbmuxd_fd >= 0)
+    {
+        // close() is POSIX-only; usbmuxd_disconnect() is the portable
+        // counterpart to usbmuxd_connect().
+        usbmuxd_disconnect(usbmuxd_fd);
+    }
+
+    usbmuxd_fd = -1;
+}
+
+void smoothtrack::run()
+{
+    // Connect to the iOS device
+    if (!connect_to_device())
+    {
+        return;
+    }
+
+    // Wrap the native socket in a QTcpSocket
+    sock = new QTcpSocket();
+    if (!sock->setSocketDescriptor(usbmuxd_fd))
+    {
+        // Ownership of usbmuxd_fd didn't transfer, so drop the socket first
+        // and let disconnect_from_device() close the descriptor itself.
+        delete sock;
+        sock = nullptr;
+        disconnect_from_device();
+        return;
+    }
+
+    QByteArray buffer;
+    buffer.resize(sizeof(last_recv_pose));
+
+    while (!isInterruptionRequested())
+    {
+        // Wait for data to be available
+        if (!sock->waitForReadyRead(100))
+        {
+            // Check if we're still connected
+            if (sock->state() != QAbstractSocket::ConnectedState)
+            {
+                break;
+            }
+            continue;
+        }
+
+        // Read available data
+        while (sock->bytesAvailable() >= static_cast<qint64>(sizeof(last_recv_pose2)))
+        {
+            QMutexLocker foo(&mutex);
+
+            bool ok = false;
+
+            // Read exactly 48 bytes (6 doubles)
+            const qint64 sz = sock->read(reinterpret_cast<char*>(last_recv_pose2), sizeof(double[6]));
+
+            if (sz == sizeof(double[6]))
+            {
+                ok = true;
+
+                // Validate the data (check for NaN and Infinite values)
+                for (unsigned i = 0; i < 6; i++)
+                {
+                    int val = std::fpclassify(last_recv_pose2[i]);
+                    if (val == FP_NAN || val == FP_INFINITE)
+                    {
+                        ok = false;
+                        break;
+                    }
+                }
+            }
+
+            if (ok)
+            {
+                for (unsigned i = 0; i < 6; i++)
+                    last_recv_pose[i] = last_recv_pose2[i];
+            }
+        }
+    }
+
+    disconnect_from_device();
+}
+
+module_status smoothtrack::start_tracker(QFrame*)
+{
+    // Start the worker thread which will handle the usbmuxd connection
+    start();
+
+    // Give the thread a moment to try connecting
+    msleep(100);
+
+    // Check if connection was successful
+    if (usbmuxd_fd < 0)
+    {
+        return error(tr("Can't connect to iOS device. Make sure:\n"
+                        "1. SmoothTrack app is running on your iOS device\n"
+                        "2. Device is connected via USB\n"
+                        "3. usbmuxd is running\n"
+                        "4. Port number matches SmoothTrack settings"));
+    }
+
+    return status_ok();
+}
+
+void smoothtrack::data(double* data)
+{
+    QMutexLocker foo(&mutex);
+    for (int i = 0; i < 6; i++)
+        data[i] = last_recv_pose[i];
+
+    int values[] = {
+        0, 90, -90, 180, -180,
+    };
+    int indices[] = {
+        s.add_yaw,
+        s.add_pitch,
+        s.add_roll,
+    };
+
+    for (int i = 0; i < 3; i++)
+    {
+        const int k = indices[i];
+        if (k >= 0 && k < std::distance(std::begin(values), std::end(values)))
+            data[Yaw + i] += values[k];
+    }
+}
+
+OPENTRACK_DECLARE_TRACKER(smoothtrack, dialog_smoothtrack, smoothtrack_metadata)

--- a/tracker-smoothtrack/ftnoir_tracker_smoothtrack.h
+++ b/tracker-smoothtrack/ftnoir_tracker_smoothtrack.h
@@ -1,0 +1,79 @@
+/* Copyright (c) 2025
+ *
+ * Permission to use, copy, modify, and/or distribute this
+ * software for any purpose with or without fee is hereby granted,
+ * provided that the above copyright notice and this permission
+ * notice appear in all copies.
+ */
+
+#pragma once
+#include "api/plugin-api.hpp"
+#include "options/options.hpp"
+#include "ui_smoothtrack-controls.h"
+#include <QTcpSocket>
+#include <QThread>
+#include <cmath>
+
+extern "C"
+{
+#include <usbmuxd.h>
+}
+
+using namespace options;
+
+struct settings : opts
+{
+    value<int> port;
+    value<int> add_yaw, add_pitch, add_roll;
+    settings()
+        : opts("smoothtrack-tracker"), port(b, "port", 47047), add_yaw(b, "add-yaw", 0), add_pitch(b, "add-pitch", 0), add_roll(b, "add-roll", 0)
+    {
+    }
+};
+
+class smoothtrack : protected QThread, public ITracker
+{
+    Q_OBJECT
+public:
+    smoothtrack();
+    ~smoothtrack() override;
+    module_status start_tracker(QFrame*) override;
+    void data(double* data) override;
+
+protected:
+    void run() override;
+
+private:
+    QTcpSocket* sock = nullptr;
+    int usbmuxd_fd = -1;
+    double last_recv_pose[6], last_recv_pose2[6];
+    QMutex mutex;
+    settings s;
+
+    bool connect_to_device();
+    void disconnect_from_device();
+};
+
+class dialog_smoothtrack : public ITrackerDialog
+{
+    Q_OBJECT
+public:
+    dialog_smoothtrack();
+    void register_tracker(ITracker*) override {}
+    void unregister_tracker() override {}
+
+private:
+    Ui::UISmoothTrackControls ui;
+    settings s;
+private slots:
+    void doOK();
+    void doCancel();
+};
+
+class smoothtrack_metadata : public Metadata
+{
+    Q_OBJECT
+
+    QString name() { return tr("SmoothTrack iOS"); }
+    QIcon icon() { return QIcon(":/images/opentrack.png"); }
+};

--- a/tracker-smoothtrack/ftnoir_tracker_smoothtrack_dialog.cpp
+++ b/tracker-smoothtrack/ftnoir_tracker_smoothtrack_dialog.cpp
@@ -1,0 +1,32 @@
+/* Copyright (c) 2025
+ *
+ * Permission to use, copy, modify, and/or distribute this
+ * software for any purpose with or without fee is hereby granted,
+ * provided that the above copyright notice and this permission
+ * notice appear in all copies.
+ */
+
+#include "ftnoir_tracker_smoothtrack.h"
+#include "api/plugin-api.hpp"
+
+dialog_smoothtrack::dialog_smoothtrack()
+{
+    ui.setupUi( this );
+
+    connect(ui.buttonBox, SIGNAL(accepted()), this, SLOT(doOK()));
+    connect(ui.buttonBox, SIGNAL(rejected()), this, SLOT(doCancel()));
+
+    tie_setting(s.port, ui.spinPortNumber);
+    tie_setting(s.add_yaw, ui.add_yaw);
+    tie_setting(s.add_pitch, ui.add_pitch);
+    tie_setting(s.add_roll, ui.add_roll);
+}
+
+void dialog_smoothtrack::doOK() {
+    s.b->save();
+    close();
+}
+
+void dialog_smoothtrack::doCancel() {
+    close();
+}

--- a/tracker-smoothtrack/lang/de_DE.ts
+++ b/tracker-smoothtrack/lang/de_DE.ts
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
+<context>
+    <name>UISmoothTrackControls</name>
+    <message>
+        <source>SmoothTrack iOS settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect your iOS device via USB and ensure SmoothTrack app is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>iOS Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to axis</source>
+        <translation type="unfinished">Zur Achse hinzufügen</translation>
+    </message>
+    <message>
+        <source>yaw</source>
+        <translation type="unfinished">Gieren</translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished">0</translation>
+    </message>
+    <message>
+        <source>+90</source>
+        <translation type="unfinished">+90</translation>
+    </message>
+    <message>
+        <source>-90</source>
+        <translation type="unfinished">-90</translation>
+    </message>
+    <message>
+        <source>+180</source>
+        <translation type="unfinished">+180</translation>
+    </message>
+    <message>
+        <source>-180</source>
+        <translation type="unfinished">-180</translation>
+    </message>
+    <message>
+        <source>pitch</source>
+        <translation type="unfinished">Nicken</translation>
+    </message>
+    <message>
+        <source>roll</source>
+        <translation type="unfinished">Rollen</translation>
+    </message>
+</context>
+<context>
+    <name>smoothtrack</name>
+    <message>
+        <source>Can&apos;t connect to iOS device. Make sure:
+1. SmoothTrack app is running on your iOS device
+2. Device is connected via USB
+3. usbmuxd is running
+4. Port number matches SmoothTrack settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>smoothtrack_metadata</name>
+    <message>
+        <source>SmoothTrack iOS</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/tracker-smoothtrack/lang/nl_NL.ts
+++ b/tracker-smoothtrack/lang/nl_NL.ts
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl_NL">
+<context>
+    <name>UISmoothTrackControls</name>
+    <message>
+        <source>SmoothTrack iOS settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect your iOS device via USB and ensure SmoothTrack app is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>iOS Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to axis</source>
+        <translation type="unfinished">Aan as toevoegen</translation>
+    </message>
+    <message>
+        <source>yaw</source>
+        <translation type="unfinished">yaw</translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished">0</translation>
+    </message>
+    <message>
+        <source>+90</source>
+        <translation type="unfinished">+90</translation>
+    </message>
+    <message>
+        <source>-90</source>
+        <translation type="unfinished">-90</translation>
+    </message>
+    <message>
+        <source>+180</source>
+        <translation type="unfinished">+180</translation>
+    </message>
+    <message>
+        <source>-180</source>
+        <translation type="unfinished">-180</translation>
+    </message>
+    <message>
+        <source>pitch</source>
+        <translation type="unfinished">pitch</translation>
+    </message>
+    <message>
+        <source>roll</source>
+        <translation type="unfinished">rol</translation>
+    </message>
+</context>
+<context>
+    <name>smoothtrack</name>
+    <message>
+        <source>Can&apos;t connect to iOS device. Make sure:
+1. SmoothTrack app is running on your iOS device
+2. Device is connected via USB
+3. usbmuxd is running
+4. Port number matches SmoothTrack settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>smoothtrack_metadata</name>
+    <message>
+        <source>SmoothTrack iOS</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/tracker-smoothtrack/lang/ru_RU.ts
+++ b/tracker-smoothtrack/lang/ru_RU.ts
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru_RU">
+<context>
+    <name>UISmoothTrackControls</name>
+    <message>
+        <source>SmoothTrack iOS settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect your iOS device via USB and ensure SmoothTrack app is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>iOS Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to axis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>+90</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-90</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>+180</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-180</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>smoothtrack</name>
+    <message>
+        <source>Can&apos;t connect to iOS device. Make sure:
+1. SmoothTrack app is running on your iOS device
+2. Device is connected via USB
+3. usbmuxd is running
+4. Port number matches SmoothTrack settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>smoothtrack_metadata</name>
+    <message>
+        <source>SmoothTrack iOS</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/tracker-smoothtrack/lang/stub.ts
+++ b/tracker-smoothtrack/lang/stub.ts
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>UISmoothTrackControls</name>
+    <message>
+        <source>SmoothTrack iOS settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect your iOS device via USB and ensure SmoothTrack app is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>iOS Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to axis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>+90</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-90</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>+180</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-180</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>smoothtrack</name>
+    <message>
+        <source>Can&apos;t connect to iOS device. Make sure:
+1. SmoothTrack app is running on your iOS device
+2. Device is connected via USB
+3. usbmuxd is running
+4. Port number matches SmoothTrack settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>smoothtrack_metadata</name>
+    <message>
+        <source>SmoothTrack iOS</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/tracker-smoothtrack/lang/zh_CN.ts
+++ b/tracker-smoothtrack/lang/zh_CN.ts
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>UISmoothTrackControls</name>
+    <message>
+        <source>SmoothTrack iOS settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect your iOS device via USB and ensure SmoothTrack app is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>iOS Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to axis</source>
+        <translation type="unfinished">添加轴向</translation>
+    </message>
+    <message>
+        <source>yaw</source>
+        <translation type="unfinished">偏航</translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>+90</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-90</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>+180</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-180</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pitch</source>
+        <translation type="unfinished">俯仰</translation>
+    </message>
+    <message>
+        <source>roll</source>
+        <translation type="unfinished">滚转</translation>
+    </message>
+</context>
+<context>
+    <name>smoothtrack</name>
+    <message>
+        <source>Can&apos;t connect to iOS device. Make sure:
+1. SmoothTrack app is running on your iOS device
+2. Device is connected via USB
+3. usbmuxd is running
+4. Port number matches SmoothTrack settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>smoothtrack_metadata</name>
+    <message>
+        <source>SmoothTrack iOS</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/tracker-smoothtrack/smoothtrack-controls.ui
+++ b/tracker-smoothtrack/smoothtrack-controls.ui
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UISmoothTrackControls</class>
+ <widget class="QWidget" name="UISmoothTrackControls">
+  <property name="windowModality">
+   <enum>Qt::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>220</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>SmoothTrack iOS settings</string>
+  </property>
+  <property name="windowIcon">
+   <iconset>
+    <normaloff>../gui/images/opentrack.png</normaloff>../gui/images/opentrack.png</iconset>
+  </property>
+  <property name="layoutDirection">
+   <enum>Qt::LeftToRight</enum>
+  </property>
+  <property name="autoFillBackground">
+   <bool>false</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <property name="horizontalSpacing">
+    <number>6</number>
+   </property>
+   <property name="verticalSpacing">
+    <number>6</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_info">
+     <property name="text">
+      <string>Connect your iOS device via USB and ensure SmoothTrack app is running.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="rightMargin">
+       <number>2</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
+      </property>
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>iOS Port</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="spinPortNumber">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Add to axis</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <property name="horizontalSpacing">
+       <number>4</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>4</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>yaw</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="add_yaw">
+        <item>
+         <property name="text">
+          <string>0</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>+90</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>-90</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>+180</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>-180</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>pitch</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>roll</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="add_pitch">
+        <item>
+         <property name="text">
+          <string>0</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>+90</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>-90</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>+180</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>-180</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="add_roll">
+        <item>
+         <property name="text">
+          <string>0</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>+90</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>-90</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>+180</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>-180</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Hi there,

This PR add a plugin to natively support SmoothTrack iOS app when connected by USB. Previously using SmoothTrack required to use another program to proxy the communication between the app and opentrack. This patch removes the need to run a separate proxy by using libimobiledevice to connect directly to the app.

I developed and tested this on Linux.

Ping @epaga for opening #1884.