### PR TITLE
Add SteamVR tracker calibration wizard and pose correction

### DIFF
--- a/tracker-steamvr/calibration-dialog.ui
+++ b/tracker-steamvr/calibration-dialog.ui
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CalibrationDialog</class>
+ <widget class="QDialog" name="CalibrationDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>350</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Calibration - Record Movements</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="instructionsLabel">
+     <property name="text">
+      <string>Press Start, perform these movements smoothly and naturally, then press Finish:
+- Turn your head left and right
+- Look up and down
+- Return to center between movements
+
+Keep your head in the same spot - only rotate, don't lean!</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="feedbackGroup">
+     <property name="title">
+      <string>Recording Status</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="statusLayout">
+        <item>
+         <widget class="QLabel" name="statusTextLabel">
+          <property name="text">
+           <string>Status:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="statusLabel">
+          <property name="text">
+           <string>Ready to record</string>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">font-weight: bold;</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="coverageTextLabel">
+        <property name="text">
+         <string>Movement detected:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="yawLayout">
+        <item>
+         <widget class="QLabel" name="yawIconLabel">
+          <property name="text">
+           <string>&lt;-&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>30</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="yawTextLabel">
+          <property name="text">
+           <string>Left/Right:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="yawStatusLabel">
+          <property name="text">
+           <string>--</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="pitchLayout">
+        <item>
+         <widget class="QLabel" name="pitchIconLabel">
+          <property name="text">
+           <string>^ v</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>30</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="pitchTextLabel">
+          <property name="text">
+           <string>Up/Down:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="pitchStatusLabel">
+          <property name="text">
+           <string>--</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="startButton">
+       <property name="text">
+        <string>Start</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="finishButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Finish</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/tracker-steamvr/dialog.ui
+++ b/tracker-steamvr/dialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>452</width>
-    <height>85</height>
+    <width>520</width>
+    <height>160</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -61,6 +61,38 @@
          </sizepolicy>
         </property>
        </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelCalibration">
+        <property name="text">
+         <string>Calibration</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="calibrationLayout">
+        <item>
+         <widget class="QPushButton" name="runCalibration">
+          <property name="text">
+           <string>Calibration wizard…</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="clearCalibration">
+          <property name="text">
+           <string>Clear</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="calibrationStatus">
+          <property name="text">
+           <string>No calibration</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/tracker-steamvr/lang/de_DE.ts
+++ b/tracker-steamvr/lang/de_DE.ts
@@ -2,6 +2,104 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="de_DE">
 <context>
+    <name>CalibrationDialog</name>
+    <message>
+        <source>Calibration - Record Movements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press Start, perform these movements smoothly and naturally, then press Finish:
+- Turn your head left and right
+- Look up and down
+- Return to center between movements
+
+Keep your head in the same spot - only rotate, don&apos;t lean!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ready to record</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>--</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Movement detected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;-&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left/Right:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>^ v</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Up/Down:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>calibration_recording_dialog</name>
+    <message>
+        <source>Calibration Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to solve calibration equations. The system may be poorly conditioned.
+Try making larger, smoother movements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Computed offset is unreasonably large (%.1f cm).
+This usually means you moved your head during recording.
+Please try again, keeping your head in the same spot while rotating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording... (ready to finish)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Good</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move more</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>dialog</name>
     <message>
         <source>Valve SteamVR</source>
@@ -9,6 +107,22 @@
     </message>
     <message>
         <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration wizard…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No calibration</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -20,6 +134,39 @@
     </message>
     <message>
         <source>Can&apos;t find device with that serial</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>steamvr_dialog</name>
+    <message>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No device selected for calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sit upright and face the screen directly. Keep your head still.
+
+Press OK to capture your neutral pose.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read pose from the selected device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration saved. It will be applied when tracking starts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/tracker-steamvr/lang/nl_NL.ts
+++ b/tracker-steamvr/lang/nl_NL.ts
@@ -2,6 +2,104 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="nl_NL">
 <context>
+    <name>CalibrationDialog</name>
+    <message>
+        <source>Calibration - Record Movements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press Start, perform these movements smoothly and naturally, then press Finish:
+- Turn your head left and right
+- Look up and down
+- Return to center between movements
+
+Keep your head in the same spot - only rotate, don&apos;t lean!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ready to record</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>--</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Movement detected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;-&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left/Right:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>^ v</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Up/Down:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>calibration_recording_dialog</name>
+    <message>
+        <source>Calibration Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to solve calibration equations. The system may be poorly conditioned.
+Try making larger, smoother movements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Computed offset is unreasonably large (%.1f cm).
+This usually means you moved your head during recording.
+Please try again, keeping your head in the same spot while rotating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording... (ready to finish)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Good</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move more</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>dialog</name>
     <message>
         <source>Valve SteamVR</source>
@@ -9,6 +107,22 @@
     </message>
     <message>
         <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration wizard…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No calibration</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -20,6 +134,39 @@
     </message>
     <message>
         <source>Can&apos;t find device with that serial</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>steamvr_dialog</name>
+    <message>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No device selected for calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sit upright and face the screen directly. Keep your head still.
+
+Press OK to capture your neutral pose.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read pose from the selected device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration saved. It will be applied when tracking starts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/tracker-steamvr/lang/ru_RU.ts
+++ b/tracker-steamvr/lang/ru_RU.ts
@@ -2,6 +2,104 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru_RU">
 <context>
+    <name>CalibrationDialog</name>
+    <message>
+        <source>Calibration - Record Movements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press Start, perform these movements smoothly and naturally, then press Finish:
+- Turn your head left and right
+- Look up and down
+- Return to center between movements
+
+Keep your head in the same spot - only rotate, don&apos;t lean!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ready to record</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>--</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Movement detected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;-&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left/Right:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>^ v</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Up/Down:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>calibration_recording_dialog</name>
+    <message>
+        <source>Calibration Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to solve calibration equations. The system may be poorly conditioned.
+Try making larger, smoother movements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Computed offset is unreasonably large (%.1f cm).
+This usually means you moved your head during recording.
+Please try again, keeping your head in the same spot while rotating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording... (ready to finish)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Good</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move more</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>dialog</name>
     <message>
         <source>Valve SteamVR</source>
@@ -9,6 +107,22 @@
     </message>
     <message>
         <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration wizard…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No calibration</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -20,6 +134,39 @@
     </message>
     <message>
         <source>Can&apos;t find device with that serial</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>steamvr_dialog</name>
+    <message>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No device selected for calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sit upright and face the screen directly. Keep your head still.
+
+Press OK to capture your neutral pose.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read pose from the selected device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration saved. It will be applied when tracking starts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/tracker-steamvr/lang/stub.ts
+++ b/tracker-steamvr/lang/stub.ts
@@ -2,6 +2,104 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>CalibrationDialog</name>
+    <message>
+        <source>Calibration - Record Movements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press Start, perform these movements smoothly and naturally, then press Finish:
+- Turn your head left and right
+- Look up and down
+- Return to center between movements
+
+Keep your head in the same spot - only rotate, don&apos;t lean!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ready to record</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>--</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Movement detected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;-&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left/Right:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>^ v</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Up/Down:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>calibration_recording_dialog</name>
+    <message>
+        <source>Calibration Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to solve calibration equations. The system may be poorly conditioned.
+Try making larger, smoother movements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Computed offset is unreasonably large (%.1f cm).
+This usually means you moved your head during recording.
+Please try again, keeping your head in the same spot while rotating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording... (ready to finish)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Good</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move more</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>dialog</name>
     <message>
         <source>Valve SteamVR</source>
@@ -9,6 +107,22 @@
     </message>
     <message>
         <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration wizard…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No calibration</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -20,6 +134,39 @@
     </message>
     <message>
         <source>Can&apos;t find device with that serial</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>steamvr_dialog</name>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No device selected for calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sit upright and face the screen directly. Keep your head still.
+
+Press OK to capture your neutral pose.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read pose from the selected device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration saved. It will be applied when tracking starts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No calibration</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/tracker-steamvr/lang/zh_CN.ts
+++ b/tracker-steamvr/lang/zh_CN.ts
@@ -2,6 +2,104 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
 <context>
+    <name>CalibrationDialog</name>
+    <message>
+        <source>Calibration - Record Movements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press Start, perform these movements smoothly and naturally, then press Finish:
+- Turn your head left and right
+- Look up and down
+- Return to center between movements
+
+Keep your head in the same spot - only rotate, don&apos;t lean!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ready to record</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>--</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Movement detected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;-&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left/Right:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>^ v</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Up/Down:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>calibration_recording_dialog</name>
+    <message>
+        <source>Calibration Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to solve calibration equations. The system may be poorly conditioned.
+Try making larger, smoother movements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Computed offset is unreasonably large (%.1f cm).
+This usually means you moved your head during recording.
+Please try again, keeping your head in the same spot while rotating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recording... (ready to finish)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Good</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move more</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>dialog</name>
     <message>
         <source>Valve SteamVR</source>
@@ -10,6 +108,22 @@
     <message>
         <source>Device</source>
         <translation>设备</translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration wizard…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No calibration</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -21,6 +135,39 @@
     <message>
         <source>Can&apos;t find device with that serial</source>
         <translation>无法找到该序列的设备</translation>
+    </message>
+</context>
+<context>
+    <name>steamvr_dialog</name>
+    <message>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No device selected for calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sit upright and face the screen directly. Keep your head still.
+
+Press OK to capture your neutral pose.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read pose from the selected device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration saved. It will be applied when tracking starts.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/tracker-steamvr/steamvr.cpp
+++ b/tracker-steamvr/steamvr.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2017, Benjamin Flegel
  * Copyright (c) 2017, Stanislaw Halik
  * Copyright (c) 2017, Anthony Coddington
- *
+ * Copyright (c) 2025, Sander Saarend
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
@@ -22,9 +22,12 @@
 
 #include <cmath>
 #include <cstdlib>
+#include <algorithm>
 
 #include <QMessageBox>
 #include <QDebug>
+#include <QCoreApplication>
+#include <QThread>
 
 QRecursiveMutex device_list::mtx;
 
@@ -210,7 +213,7 @@ module_status steamvr::start_tracker(QFrame*)
 
         for (const device_spec& spec : specs)
         {
-            if (serial == "" || serial == spec.to_string())
+            if (serial.isEmpty() || serial == spec.to_string())
             {
                 device_index = spec.k;
                 break;
@@ -225,6 +228,19 @@ module_status steamvr::start_tracker(QFrame*)
             if (auto* c = vr::VRCompositor(); c != nullptr)
             {
                 c->SetTrackingSpace(origin::TrackingUniverseSeated);
+                
+                QMutexLocker lock(&calibration_mtx);
+                calibration_ready = false;
+                steamvr::mat34 m;
+                if (s.calibration_enabled() && from_variant_list(s.calibration_matrix(), m))
+                {
+                    calibration_offset = m;
+                    calibration_ready = true;
+                }
+                else if (s.calibration_enabled())
+                {
+                    eval_once(qDebug() << "steamvr: failed to load calibration matrix");
+                }
                 return status_ok();
             }
             else
@@ -242,15 +258,28 @@ void steamvr::data(double* data)
         auto [ok, pose] = device_list::get_pose(device_index);
         if (ok)
         {
+            // Scale factor for converting meters to centimeters
             constexpr int c = 10;
 
-            const auto& result = pose.mDeviceToAbsoluteTracking;
+            const auto& result_raw = pose.mDeviceToAbsoluteTracking;
+            vr::HmdMatrix34_t corrected = result_raw;
 
-            data[TX] = (double)(-result.m[0][3] * c);
-            data[TY] = (double)(result.m[1][3] * c);
-            data[TZ] = (double)(result.m[2][3] * c);
+            // Apply calibration offset if available
+            {
+                QMutexLocker lock(&calibration_mtx);
+                if (calibration_ready)
+                {
+                    mat34 raw = from_vr_matrix(result_raw);
+                    mat34 corrected_mat = multiply(raw, calibration_offset);
+                    corrected = to_vr_matrix(corrected_mat);
+                }
+            }
 
-            matrix_to_euler(data[Yaw], data[Pitch], data[Roll], result);
+            data[TX] = (double)(-corrected.m[0][3] * c);
+            data[TY] = (double)(corrected.m[1][3] * c);
+            data[TZ] = (double)(corrected.m[2][3] * c);
+
+            matrix_to_euler(data[Yaw], data[Pitch], data[Roll], corrected);
 
             constexpr double r2d = 180 / M_PI;
             data[Yaw] *= r2d; data[Pitch] *= r2d; data[Roll] *= r2d;
@@ -297,12 +326,144 @@ void steamvr::matrix_to_euler(double& yaw, double& pitch, double& roll, const vr
     roll = std::asin(d(result.m[1][0]));
 }
 
+void steamvr::matrix_to_euler(double& yaw, double& pitch, double& roll, const mat34& mat)
+{
+    yaw = std::atan2(mat.m[2][0], mat.m[0][0]);
+    pitch = std::atan2(-mat.m[1][2], mat.m[1][1]);
+    roll = std::asin(mat.m[1][0]);
+}
+
+auto steamvr::identity_matrix() -> mat34
+{
+    mat34 out;
+    out.m[0][0] = out.m[1][1] = out.m[2][2] = 1.0;
+    return out;
+}
+
+auto steamvr::from_vr_matrix(const vr::HmdMatrix34_t& mat) -> mat34
+{
+    mat34 out;
+    for (int r = 0; r < 3; r++)
+        for (int c = 0; c < 4; c++)
+            out.m[r][c] = mat.m[r][c];
+    return out;
+}
+
+auto steamvr::to_vr_matrix(const mat34& mat) -> vr::HmdMatrix34_t
+{
+    vr::HmdMatrix34_t out{};
+    for (int r = 0; r < 3; r++)
+        for (int c = 0; c < 4; c++)
+            out.m[r][c] = float(mat.m[r][c]);
+    return out;
+}
+
+// Multiplies two rigid transformation matrices (3x4 augmented format).
+// Computes C = A * B where matrices are in [R|t] form (3x3 rotation + 3x1 translation).
+auto steamvr::multiply(const mat34& a, const mat34& b) -> mat34
+{
+    mat34 out{};
+    for (int r = 0; r < 3; r++)
+    {
+        for (int c = 0; c < 3; c++)
+        {
+            double v = 0;
+            for (int k = 0; k < 3; k++)
+                v += a.m[r][k] * b.m[k][c];
+            out.m[r][c] = v;
+        }
+
+        double t = 0;
+        for (int k = 0; k < 3; k++)
+            t += a.m[r][k] * b.m[k][3];
+        out.m[r][3] = t + a.m[r][3];
+    }
+    return out;
+}
+
+// Serializes a 3x4 matrix to QVariantList for storage.
+// Row-major order: [m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23]
+auto steamvr::to_variant_list(const mat34& mat) -> QVariantList
+{
+    QVariantList list;
+    list.reserve(12);
+    for (int r = 0; r < 3; r++)
+        for (int c = 0; c < 4; c++)
+            list << mat.m[r][c];
+    return list;
+}
+
+// Deserializes a 3x4 matrix from QVariantList.
+// Expects 12 elements in row-major order.
+bool steamvr::from_variant_list(const QVariantList& list, mat34& out)
+{
+    if (list.size() != 12)
+        return false;
+
+    for (int i = 0; i < 12; i++)
+        out.m[i / 4][i % 4] = list[i].toDouble();
+    return true;
+}
+
+namespace {
+// Solves a 3x3 linear system Ax = b using Gaussian elimination with partial pivoting.
+// Modifies A and b in place. Returns false if the system is singular (determinant near zero).
+// This is used in calibration to solve for the tracker-to-head offset vector.
+bool solve_3x3(double A[3][3], double b[3], double out[3])
+{
+    constexpr double epsilon = 1e-9;
+    
+    for (int i = 0; i < 3; i++)
+    {
+        // Find pivot row
+        int pivot = i;
+        for (int r = i + 1; r < 3; r++)
+            if (std::abs(A[r][i]) > std::abs(A[pivot][i]))
+                pivot = r;
+
+        // Check for singular matrix
+        if (std::abs(A[pivot][i]) < epsilon)
+            return false;
+
+        // Swap rows if needed
+        if (pivot != i)
+        {
+            for (int c = 0; c < 3; c++)
+                std::swap(A[i][c], A[pivot][c]);
+            std::swap(b[i], b[pivot]);
+        }
+
+        // Normalize pivot row
+        const double div = A[i][i];
+        for (int c = i; c < 3; c++)
+            A[i][c] /= div;
+        b[i] /= div;
+
+        // Eliminate column in other rows
+        for (int r = 0; r < 3; r++)
+        {
+            if (r == i) continue;
+            const double factor = A[r][i];
+            for (int c = i; c < 3; c++)
+                A[r][c] -= factor * A[i][c];
+            b[r] -= factor * b[i];
+        }
+    }
+
+    for (int i = 0; i < 3; i++)
+        out[i] = b[i];
+    return true;
+}
+} // namespace
+
 steamvr_dialog::steamvr_dialog()
 {
     ui.setupUi(this);
 
     connect(ui.buttonBox, SIGNAL(accepted()), this, SLOT(doOK()));
     connect(ui.buttonBox, SIGNAL(rejected()), this, SLOT(doCancel()));
+    connect(ui.runCalibration, &QPushButton::clicked, this, &steamvr_dialog::doRunCalibration);
+    connect(ui.clearCalibration, &QPushButton::clicked, this, &steamvr_dialog::doClearCalibration);
 
     ui.device->clear();
     ui.device->addItem("First available", QVariant(QVariant::String));
@@ -317,6 +478,8 @@ steamvr_dialog::steamvr_dialog()
     }
 
     tie_setting(s.device_serial, ui.device);
+
+    update_calibration_label();
 }
 
 void steamvr_dialog::doOK()
@@ -330,7 +493,323 @@ void steamvr_dialog::doCancel()
     close();
 }
 
+void steamvr_dialog::update_calibration_label()
+{
+    if (s.calibration_enabled())
+        ui.calibrationStatus->setText(tr("Saved"));
+    else
+        ui.calibrationStatus->setText(tr("No calibration"));
+}
 
+void steamvr_dialog::doRunCalibration()
+{
+    run_calibration_wizard();
+}
+
+void steamvr_dialog::run_calibration_wizard()
+{
+    const QString serial = ui.device->currentData().toString();
+    device_list d;
+    unsigned idx = UINT_MAX;
+
+    for (const device_spec& spec : d.devices())
+    {
+        if (serial.isEmpty() || serial == spec.to_string())
+        {
+            idx = spec.k;
+            break;
+        }
+    }
+
+    if (idx == UINT_MAX)
+    {
+        QMessageBox::warning(this, tr("Calibration"), tr("No device selected for calibration."));
+        return;
+    }
+
+    // Step 1: Capture neutral pose
+    QMessageBox::information(this, tr("Calibration"),
+                             tr("Sit upright and face the screen directly. Keep your head still.\n\n"
+                                "Press OK to capture your neutral pose."));
+
+    // Check device stability by sampling multiple poses
+    constexpr int stability_samples = 10;
+    constexpr double max_position_variance = 0.001; // 1mm variance
+    std::vector<steamvr::mat34> stability_check_poses;
+    stability_check_poses.reserve(stability_samples);
+    
+    for (int i = 0; i < stability_samples; i++)
+    {
+        auto [ok, pose] = device_list::get_pose(idx);
+        if (!ok)
+        {
+            QMessageBox::warning(this, tr("Calibration"), tr("Unable to read pose from the selected device."));
+            return;
+        }
+        stability_check_poses.push_back(steamvr::from_vr_matrix(pose.mDeviceToAbsoluteTracking));
+        QThread::msleep(50); // 50ms between samples
+    }
+    
+    // Check position stability
+    double mean_pos[3] = {0, 0, 0};
+    for (const auto& p : stability_check_poses)
+        for (int i = 0; i < 3; i++)
+            mean_pos[i] += p.m[i][3];
+    for (int i = 0; i < 3; i++)
+        mean_pos[i] /= stability_samples;
+    
+    double variance = 0;
+    for (const auto& p : stability_check_poses)
+        for (int i = 0; i < 3; i++)
+        {
+            double diff = p.m[i][3] - mean_pos[i];
+            variance += diff * diff;
+        }
+    variance /= (stability_samples * 3);
+    
+    if (variance > max_position_variance)
+    {
+        QMessageBox::warning(this, tr("Calibration"),
+                           tr("Device tracking is unstable. Please ensure the device is properly tracking\n"
+                              "and keep your head completely still during the neutral pose capture.\n\n"
+                              "Position variance: %.2f mm").arg(std::sqrt(variance) * 1000));
+        return;
+    }
+    
+    // Use the most recent pose as the base pose
+    steamvr::mat34 base_pose = stability_check_poses.back();
+
+    // Step 2: Record movements with live feedback
+    calibration_recording_dialog recording_dialog(idx, base_pose, this);
+    steamvr::mat34 offset;
+    
+    if (!recording_dialog.run(offset))
+    {
+        // User cancelled or calibration failed
+        return;
+    }
+
+    // Save calibration
+    s.calibration_matrix = steamvr::to_variant_list(offset);
+    s.calibration_enabled = true;
+    s.b->save();
+
+    update_calibration_label();
+    QMessageBox::information(this, tr("Calibration"), tr("Calibration saved. It will be applied when tracking starts."));
+}
+
+void steamvr_dialog::doClearCalibration()
+{
+    s.calibration_enabled = false;
+    s.calibration_matrix = QVariantList();
+    s.b->save();
+    update_calibration_label();
+}
+
+// Calibration Recording Dialog Implementation
+
+calibration_recording_dialog::calibration_recording_dialog(unsigned device_idx, const steamvr::mat34& base_pose, QWidget* parent)
+    : QDialog(parent), device_idx(device_idx), base_pose(base_pose)
+{
+    ui.setupUi(this);
+    
+    sample_timer = new QTimer(this);
+    sample_timer->setInterval(sample_interval_ms);
+    
+    connect(ui.startButton, &QPushButton::clicked, this, &calibration_recording_dialog::on_startButton_clicked);
+    connect(ui.finishButton, &QPushButton::clicked, this, &calibration_recording_dialog::on_finishButton_clicked);
+    connect(ui.cancelButton, &QPushButton::clicked, this, &calibration_recording_dialog::on_cancelButton_clicked);
+    connect(sample_timer, &QTimer::timeout, this, &calibration_recording_dialog::on_sample_timer);
+}
+
+bool calibration_recording_dialog::run(steamvr::mat34& out_offset)
+{
+    exec();
+    
+    if (!finished_successfully)
+        return false;
+    
+    // Compute calibration from collected samples
+    // Algorithm: Estimate the offset from tracker to head pivot point using least squares.
+    // The constraint is: when the head rotates (changing R), the tracker translates (changing t),
+    // but the head pivot point stays fixed. This gives us: dR * offset = -dp
+    // We solve this overdetermined system in a least-squares sense.
+    
+    double ATA[3][3] {};
+    double ATb[3] {};
+    
+    for (const auto& sample : samples)
+    {
+        // Change in position and rotation relative to base pose
+        double dp[3] {
+            sample.pose.m[0][3] - base_pose.m[0][3],
+            sample.pose.m[1][3] - base_pose.m[1][3],
+            sample.pose.m[2][3] - base_pose.m[2][3],
+        };
+        
+        double dR[3][3];
+        for (int r = 0; r < 3; r++)
+            for (int c = 0; c < 3; c++)
+                dR[r][c] = sample.pose.m[r][c] - base_pose.m[r][c];
+        
+        // Build normal equations: A^T * A and A^T * b
+        for (int r = 0; r < 3; r++)
+        {
+            for (int c = 0; c < 3; c++)
+            {
+                ATb[c] -= dR[r][c] * dp[r];
+                for (int k = 0; k < 3; k++)
+                    ATA[c][k] += dR[r][c] * dR[r][k];
+            }
+        }
+    }
+    
+    double offset_tracker_to_head[3] {};
+    if (!solve_3x3(ATA, ATb, offset_tracker_to_head))
+    {
+        QMessageBox::warning(this, tr("Calibration Failed"),
+                            tr("Unable to solve calibration equations. The system may be poorly conditioned.\n"
+                               "Try making larger, smoother movements."));
+        return false;
+    }
+    
+    // Validate that the offset is reasonable (not a numerical artifact)
+    constexpr double max_reasonable_offset_m = 0.5; // 50cm
+    double offset_magnitude = std::sqrt(offset_tracker_to_head[0] * offset_tracker_to_head[0] +
+                                       offset_tracker_to_head[1] * offset_tracker_to_head[1] +
+                                       offset_tracker_to_head[2] * offset_tracker_to_head[2]);
+    
+    if (offset_magnitude > max_reasonable_offset_m)
+    {
+        QMessageBox::warning(this, tr("Calibration Failed"),
+                            tr("Computed offset is unreasonably large (%.1f cm).\n"
+                               "This usually means you moved your head during recording.\n"
+                               "Please try again, keeping your head in the same spot while rotating.")
+                            .arg(offset_magnitude * 100));
+        return false;
+    }
+    
+    // Build the calibration offset matrix:
+    // - Rotation part: transpose of base rotation (aligns neutral pose to identity)
+    // - Translation part: estimated offset from tracker to head pivot
+    out_offset = steamvr::identity_matrix();
+    for (int r = 0; r < 3; r++)
+    {
+        for (int c = 0; c < 3; c++)
+            out_offset.m[r][c] = base_pose.m[c][r]; // Transpose
+        out_offset.m[r][3] = offset_tracker_to_head[r];
+    }
+    
+    return true;
+}
+
+void calibration_recording_dialog::on_startButton_clicked()
+{
+    samples.clear();
+    finished_successfully = false;
+
+    // Initialize coverage to the current pose so neutral orientation doesn't count as movement
+    double start_yaw = 0;
+    double start_pitch = 0;
+    double start_roll = 0;
+    if (auto [ok, pose] = device_list::get_pose(device_idx); ok)
+    {
+        auto start_pose = steamvr::from_vr_matrix(pose.mDeviceToAbsoluteTracking);
+        steamvr::matrix_to_euler(start_yaw, start_pitch, start_roll, start_pose);
+    }
+    min_yaw = max_yaw = start_yaw;
+    min_pitch = max_pitch = start_pitch;
+
+    ui.yawStatusLabel->setText("--");
+    ui.pitchStatusLabel->setText("--");
+
+    ui.startButton->setEnabled(false);
+    ui.statusLabel->setText(tr("Recording..."));
+    sample_timer->start();
+}
+
+void calibration_recording_dialog::on_finishButton_clicked()
+{
+    sample_timer->stop();
+    finished_successfully = true;
+    accept();
+}
+
+void calibration_recording_dialog::on_cancelButton_clicked()
+{
+    sample_timer->stop();
+    finished_successfully = false;
+    reject();
+}
+
+void calibration_recording_dialog::on_sample_timer()
+{
+    auto [ok, pose] = device_list::get_pose(device_idx);
+    if (!ok)
+        return;
+    
+    steamvr::mat34 current_pose = steamvr::from_vr_matrix(pose.mDeviceToAbsoluteTracking);
+    
+    sample_data sample;
+    sample.pose = current_pose;
+    double roll; // unused, but needed for the function call
+    steamvr::matrix_to_euler(sample.yaw, sample.pitch, roll, current_pose);
+    
+    samples.push_back(sample);
+    
+    // Update coverage tracking
+    min_yaw = std::min(min_yaw, sample.yaw);
+    max_yaw = std::max(max_yaw, sample.yaw);
+    min_pitch = std::min(min_pitch, sample.pitch);
+    max_pitch = std::max(max_pitch, sample.pitch);
+    
+    update_ui();
+    
+    // Enable finish button when requirements are met
+    bool enough_samples = samples.size() >= min_samples;
+    bool good_coverage = check_coverage();
+    ui.finishButton->setEnabled(enough_samples && good_coverage);
+    
+    if (good_coverage && enough_samples)
+    {
+        ui.statusLabel->setText(tr("Recording... (ready to finish)"));
+    }
+}
+
+void calibration_recording_dialog::update_ui()
+{
+    // Update yaw coverage
+    constexpr double deg = 180.0 / M_PI;
+    double yaw_range = (max_yaw - min_yaw) * deg;
+    double pitch_range = (max_pitch - min_pitch) * deg;
+    
+    if (samples.size() < 5)
+    {
+        ui.yawStatusLabel->setText("--");
+        ui.pitchStatusLabel->setText("--");
+    }
+    else
+    {
+        if (yaw_range >= min_yaw_range_deg)
+            ui.yawStatusLabel->setText(tr("Good"));
+        else
+            ui.yawStatusLabel->setText(tr("Move more"));
+        
+        if (pitch_range >= min_pitch_range_deg)
+            ui.pitchStatusLabel->setText(tr("Good"));
+        else
+            ui.pitchStatusLabel->setText(tr("Move more"));
+    }
+}
+
+bool calibration_recording_dialog::check_coverage() const
+{
+    constexpr double deg = 180.0 / M_PI;
+    double yaw_range = (max_yaw - min_yaw) * deg;
+    double pitch_range = (max_pitch - min_pitch) * deg;
+    
+    return yaw_range >= min_yaw_range_deg && pitch_range >= min_pitch_range_deg;
+}
 
 QString device_spec::to_string() const
 {


### PR DESCRIPTION
Related: https://github.com/opentrack/opentrack/discussions/1778

This PR improves the tracking with SteamVR trackers. Such trackers can be mounted in different ways, with different orientations and offsets. I have not been able to account for this with the current configuration tools available in opentrack, because head movement in one axis can get interpreted as movements in multiple axes on the tracker, depending on the placement of the device.

This PR adds a calibration wizard for calibrating the position of a SteamVR tracker. The wizard asks the user to move their head in two axes, and uses that to calculate the position of the tracker.

Screenshots:

<img width="440" height="183" alt="{8F16FD97-11CB-4670-8804-EFBDEC28A893}" src="https://github.com/user-attachments/assets/e5192939-72cf-48ce-ba0e-ad8761cbcbe7" />
<img width="429" height="158" alt="{A6049C72-F139-4143-BC2B-B3AFEC6CD561}" src="https://github.com/user-attachments/assets/69f6944e-9ebf-4ff0-88c2-72395bde12b8" />
<img width="527" height="407" alt="{B1D4FA4C-6F76-460D-A638-6E7D12476D54}" src="https://github.com/user-attachments/assets/d33b5a82-eba2-4358-b897-a97355c4db5b" />

Screen recording of behavior when moving head left and right, up and down - default behavior (same as `master` branch) on the left, calibrated tracker on the right:

[2025-11-28 12-43-41.webm](https://github.com/user-attachments/assets/15fa613a-13c3-4483-b0ac-173eeddfb7f8)



Tested with a [Tundra tracker device](https://tundra-labs.com/) mounted on the right side of my headphones