### PR TITLE
tracker/nn: Add option to disable internal filtering

### DIFF
--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
@@ -406,7 +406,7 @@ QuatPose NeuralNetTracker::transform_to_world_pose(const cv::Quatf& face_rotatio
 
 QuatPose NeuralNetTracker::compute_filtered_pose(const PoseEstimator::Face& face)
 {
-    if (fps_ > 0.001 && last_pose_ && poseestimator_->has_uncertainty())
+    if (fps_ > 0.001 && last_pose_ && poseestimator_->has_uncertainty() && settings_.internal_filter_enabled)
     {
         auto image2world = [this](const cv::Quatf& face_rotation, const cv::Point2f& face_xy, const float face_size)
         { return this->transform_to_world_pose(face_rotation, face_xy, face_size); };
@@ -720,6 +720,7 @@ NeuralNetDialog::NeuralNetDialog() : trans_calib_(1, 2)
     tie_setting(settings_.resolution, ui_.resolution);
     tie_setting(settings_.force_fps, ui_.cameraFPS);
     tie_setting(settings_.posenet_file, ui_.posenetFileDisplay);
+    tie_setting(settings_.internal_filter_enabled, ui_.internal_filter_enabled);
 
     connect(ui_.buttonBox, SIGNAL(accepted()), this, SLOT(doOK()));
     connect(ui_.buttonBox, SIGNAL(rejected()), this, SLOT(doCancel()));

--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.h
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.h
@@ -90,6 +90,7 @@ struct Settings : opts
     value<double> deadzone_size{ b, "deadzone-size", 1. };
     value<double> deadzone_hardness{ b, "deadzone-hardness", 1.5 };
     value<QString> posenet_file{ b, "posenet-file", "head-pose-0.4-big-int8.onnx" };
+    value<bool> internal_filter_enabled{ b, "internal-filter-enabled", false };
     Settings();
 };
 

--- a/tracker-neuralnet/lang/de_DE.ts
+++ b/tracker-neuralnet/lang/de_DE.ts
@@ -38,6 +38,26 @@ Bitte nicht rollen oder die Position ändern.</translation>
         <translation>Kalibrierung starten</translation>
     </message>
     <message>
+        <source>Internal Noise Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Face Crop Options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Smoothing Alpha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Camera Configuration</source>
         <translation>Kamera-Konfiguration</translation>
     </message>
@@ -94,20 +114,8 @@ Bitte nicht rollen oder die Position ändern.</translation>
         <translation>Zeigt den Bildausschnitt, den das Modell zur Posenabschätzung sieht.</translation>
     </message>
     <message>
-        <source>Show Network Input</source>
-        <translation>Zeige Netzwerk-Eingabe</translation>
-    </message>
-    <message>
-        <source>ROI Smoothing Alpha</source>
-        <translation>ROI-Glättungsalpha</translation>
-    </message>
-    <message>
         <source>Amount of smoothing of the face region coordinates. Can help stabilize the pose.</source>
         <translation>Umfang der Glättung der Gesichtkoordinaten. Kann helfen, die Pose zu stabilisieren.</translation>
-    </message>
-    <message>
-        <source>ROI Zoom</source>
-        <translation>ROI-Zoom</translation>
     </message>
     <message>
         <source>Zoom factor for the face region. Applied before the patch is fed into the pose estimation model. There is a sweet spot near 1.</source>

--- a/tracker-neuralnet/lang/nl_NL.ts
+++ b/tracker-neuralnet/lang/nl_NL.ts
@@ -57,7 +57,7 @@ Don&apos;t roll or change position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Network Input</source>
+        <source>Face Crop Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -66,14 +66,6 @@ Don&apos;t roll or change position.</source>
     </message>
     <message>
         <source>Tuning / Debug</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>ROI Smoothing Alpha</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>ROI Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -109,7 +101,23 @@ Don&apos;t roll or change position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Internal Noise Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Zoom factor for the face region. Applied before the patch is fed into the pose estimation model. There is a sweet spot near 1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Smoothing Alpha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/tracker-neuralnet/lang/ru_RU.ts
+++ b/tracker-neuralnet/lang/ru_RU.ts
@@ -58,8 +58,8 @@ Don&apos;t roll or change position.</source>
         <translation>Вверх</translation>
     </message>
     <message>
-        <source>Show Network Input</source>
-        <translation>Показать входные данные</translation>
+        <source>Face Crop Options:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>MJPEG</source>
@@ -68,14 +68,6 @@ Don&apos;t roll or change position.</source>
     <message>
         <source>Tuning / Debug</source>
         <translation>Тонкая настройка</translation>
-    </message>
-    <message>
-        <source>ROI Smoothing Alpha</source>
-        <translation>Сглаживание ROI</translation>
-    </message>
-    <message>
-        <source>ROI Zoom</source>
-        <translation>Масштабирование ROI</translation>
     </message>
     <message>
         <source>Thread Count</source>
@@ -110,8 +102,24 @@ Don&apos;t roll or change position.</source>
         <translation>Сглаживание координат области лица. Может помочь стабилизировать позицию.</translation>
     </message>
     <message>
+        <source>Internal Noise Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Zoom factor for the face region. Applied before the patch is fed into the pose estimation model. There is a sweet spot near 1.</source>
         <translation>Фактор масштабирования области лица. Применяется перед передачей кадра в модель определения позиции. Наилучшие результаты близки к 1</translation>
+    </message>
+    <message>
+        <source>Smoothing Alpha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select Pose Net ONNX</source>

--- a/tracker-neuralnet/lang/stub.ts
+++ b/tracker-neuralnet/lang/stub.ts
@@ -57,7 +57,7 @@ Don&apos;t roll or change position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Network Input</source>
+        <source>Face Crop Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -66,14 +66,6 @@ Don&apos;t roll or change position.</source>
     </message>
     <message>
         <source>Tuning / Debug</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>ROI Smoothing Alpha</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>ROI Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -109,7 +101,23 @@ Don&apos;t roll or change position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Internal Noise Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Zoom factor for the face region. Applied before the patch is fed into the pose estimation model. There is a sweet spot near 1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Smoothing Alpha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/tracker-neuralnet/lang/zh_CN.ts
+++ b/tracker-neuralnet/lang/zh_CN.ts
@@ -8,6 +8,22 @@
         <translation>追踪器设置</translation>
     </message>
     <message>
+        <source>Internal Noise Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Smoothing Alpha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Diagonal FOV</source>
         <translation>对角线视场角</translation>
     </message>
@@ -58,24 +74,12 @@ Don&apos;t roll or change position.</source>
         <translation>向上</translation>
     </message>
     <message>
-        <source>Show Network Input</source>
-        <translation>显示神经网络输入</translation>
-    </message>
-    <message>
         <source>MJPEG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Tuning / Debug</source>
         <translation>调整/调试</translation>
-    </message>
-    <message>
-        <source>ROI Smoothing Alpha</source>
-        <translation>图像ROI区域平滑</translation>
-    </message>
-    <message>
-        <source>ROI Zoom</source>
-        <translation>图像ROI区域缩放</translation>
     </message>
     <message>
         <source>Thread Count</source>
@@ -100,6 +104,10 @@ Don&apos;t roll or change position.</source>
     <message>
         <source>Number of threads. Can be used to balance the CPU load between the game and the tracker.</source>
         <translation>线程数，用于平衡游戏进程与跟踪器的CPU资源占用。</translation>
+    </message>
+    <message>
+        <source>Face Crop Options:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show the image patch that the pose estimation model sees.</source>

--- a/tracker-neuralnet/neuralnet-trackercontrols.ui
+++ b/tracker-neuralnet/neuralnet-trackercontrols.ui
@@ -173,12 +173,24 @@
          </size>
         </property>
         <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
+         <enum>QFrame::Shape::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="leftMargin">
+          <number>2</number>
+         </property>
+         <property name="topMargin">
+          <number>2</number>
+         </property>
+         <property name="rightMargin">
+          <number>2</number>
+         </property>
+         <property name="bottomMargin">
+          <number>2</number>
+         </property>
          <item>
           <widget class="QLabel" name="label_59">
            <property name="text">
@@ -186,7 +198,7 @@
 Don't roll or change position.</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignCenter</set>
+            <set>Qt::AlignmentFlag::AlignCenter</set>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -205,10 +217,10 @@ Don't roll or change position.</string>
             </sizepolicy>
            </property>
            <property name="frameShape">
-            <enum>QFrame::Panel</enum>
+            <enum>QFrame::Shape::Panel</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Sunken</enum>
+            <enum>QFrame::Shadow::Sunken</enum>
            </property>
            <property name="text">
             <string/>
@@ -237,10 +249,287 @@ Don't roll or change position.</string>
      </layout>
     </widget>
    </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="resolution_display">
+     <property name="autoFillBackground">
+      <bool>true</bool>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Shape::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Shadow::Sunken</enum>
+     </property>
+     <property name="text">
+      <string notr="true"/>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QGroupBox" name="tuningOptionsBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="autoFillBackground">
+      <bool>true</bool>
+     </property>
+     <property name="title">
+      <string>Tuning / Debug</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="threadCountLabel">
+          <property name="text">
+           <string>Thread Count</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="threadCount">
+          <property name="toolTip">
+           <string>Number of threads. Can be used to balance the CPU load between the game and the tracker.</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>32</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Line" name="line">
+          <property name="orientation">
+           <enum>Qt::Orientation::Vertical</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="internal_filter_enabled">
+          <property name="text">
+           <string>Internal Noise Filter</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="Line" name="line_2">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Face Crop Options:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="showNetworkInput">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Show the image patch that the pose estimation model sees.</string>
+          </property>
+          <property name="text">
+           <string>Show</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="roiFilterAlphaLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Smoothing Alpha</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="roiFilterAlpha">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>150</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Amount of smoothing of the face region coordinates. Can help stabilize the pose.</string>
+          </property>
+          <property name="wrapping">
+           <bool>false</bool>
+          </property>
+          <property name="decimals">
+           <number>2</number>
+          </property>
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="roiZoomLabel">
+          <property name="text">
+           <string>Zoom</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="roiZoom">
+          <property name="toolTip">
+           <string>Zoom factor for the face region. Applied before the patch is fed into the pose estimation model. There is a sweet spot near 1.</string>
+          </property>
+          <property name="minimum">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>2.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="Line" name="line_3">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QFrame" name="network_select_frame">
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Shadow::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="posenetSelectButton">
+           <property name="toolTip">
+            <string>Select the pose network. Changes take affect on the next tracker start</string>
+           </property>
+           <property name="text">
+            <string>Select Pose Net ONNX</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="posenetFileDisplay">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&lt;the pose net file&gt;</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="8" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
@@ -274,7 +563,7 @@ Don't roll or change position.</string>
       <item>
        <layout class="QGridLayout" name="gridLayout_3">
         <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
+         <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
         </property>
         <property name="leftMargin">
          <number>0</number>
@@ -442,233 +731,6 @@ Don't roll or change position.</string>
          </widget>
         </item>
        </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="resolution_display">
-     <property name="autoFillBackground">
-      <bool>true</bool>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Sunken</enum>
-     </property>
-     <property name="text">
-      <string notr="true"/>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QGroupBox" name="tuningOptionsBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="autoFillBackground">
-      <bool>true</bool>
-     </property>
-     <property name="title">
-      <string>Tuning / Debug</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="threadCountLabel">
-          <property name="text">
-           <string>Thread Count</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="threadCount">
-          <property name="toolTip">
-           <string>Number of threads. Can be used to balance the CPU load between the game and the tracker.</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>32</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Line" name="line">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="showNetworkInput">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Show the image patch that the pose estimation model sees.</string>
-          </property>
-          <property name="text">
-           <string>Show Network Input</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Line" name="line_2">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="roiFilterAlphaLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>ROI Smoothing Alpha</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="roiFilterAlpha">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>150</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Amount of smoothing of the face region coordinates. Can help stabilize the pose.</string>
-          </property>
-          <property name="wrapping">
-           <bool>false</bool>
-          </property>
-          <property name="decimals">
-           <number>2</number>
-          </property>
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="roiZoomLabel">
-          <property name="text">
-           <string>ROI Zoom</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="roiZoom">
-          <property name="toolTip">
-           <string>Zoom factor for the face region. Applied before the patch is fed into the pose estimation model. There is a sweet spot near 1.</string>
-          </property>
-          <property name="minimum">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>2.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QFrame" name="network_select_frame">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QPushButton" name="posenetSelectButton">
-           <property name="toolTip">
-            <string>Select the pose network. Changes take affect on the next tracker start</string>
-           </property>
-           <property name="text">
-            <string>Select Pose Net ONNX</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="posenetFileDisplay">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>&lt;the pose net file&gt;</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Hi @sthalik 

This PR adds a toggle for the internal filtering in the NN tracker. Maybe I'll remove the feature entirely later on. Made this now for testing.

I also changed the UI a bit for more clarity.

<img width="584" height="170" alt="image" src="https://github.com/user-attachments/assets/7f8796ef-80ec-4364-891e-f6ee930ddfdd" />
