### PR TITLE
video/opencv: force V4L2 framerate via direct ioctl

### DIFF
--- a/video-opencv/impl-camera.cpp
+++ b/video-opencv/impl-camera.cpp
@@ -1,6 +1,16 @@
 #include "impl.hpp"
 #include "compat/sleep.hpp"
 #include "video-property-page.hpp"
+
+#ifdef __linux__
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/videodev2.h>
+#include <QDebug>
+#include <QString>
+#endif
+
 #include <opencv2/core/utils/logger.hpp>
 
 namespace opencv_camera_impl {
@@ -31,6 +41,53 @@ bool cam::is_open()
     return !!cap;
 }
 
+#ifdef __linux__
+static bool force_v4l2_fps(int camera_idx, int fps)
+{
+    if (fps <= 0)
+        return true;
+
+    QString dev_path = QString("/dev/video%1").arg(camera_idx);
+    int fd = open(dev_path.toUtf8().constData(), O_RDWR);
+    if (fd < 0)
+    {
+        qDebug() << "video/opencv: v4l2 can't open" << dev_path;
+        return false;
+    }
+
+    struct v4l2_streamparm parm = {};
+    parm.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+
+    if (ioctl(fd, VIDIOC_G_PARM, &parm) < 0)
+    {
+        qDebug() << "video/opencv: VIDIOC_G_PARM failed";
+        close(fd);
+        return false;
+    }
+
+    parm.parm.capture.timeperframe.numerator = 1;
+    parm.parm.capture.timeperframe.denominator = fps;
+
+    if (ioctl(fd, VIDIOC_S_PARM, &parm) < 0)
+    {
+        qDebug() << "video/opencv: VIDIOC_S_PARM failed for" << fps << "fps";
+        close(fd);
+        return false;
+    }
+
+    ioctl(fd, VIDIOC_G_PARM, &parm);
+    int actual_fps = parm.parm.capture.timeperframe.denominator /
+                     (parm.parm.capture.timeperframe.numerator
+                      ? parm.parm.capture.timeperframe.numerator : 1);
+
+    qDebug() << "video/opencv: v4l2 framerate set to" << actual_fps << "fps"
+             << "(requested" << fps << "fps)";
+
+    close(fd);
+    return actual_fps == fps;
+}
+#endif
+
 bool cam::start(info& args)
 {
     stop();
@@ -53,6 +110,10 @@ bool cam::start(info& args)
 #if defined _WIN32 || defined __APPLE__
     if (args.use_mjpeg)
         cap->set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('M', 'J', 'P', 'G'));
+#endif
+
+#ifdef __linux__
+    force_v4l2_fps(idx, args.fps);
 #endif
 
     if (!cap->isOpened())


### PR DESCRIPTION
OpenCV's `CAP_PROP_FPS` doesn't call the V4L2 `VIDIOC_S_PARM` ioctl, so the camera stays at its power-on default framerate. This adds a direct ioctl call after OpenCV setup to reliably set the capture framerate on Linux.

Tested with an ELP AR0234 global shutter camera at 90fps where `CAP_PROP_FPS` was silently failing. Linux-only, guarded by `#ifdef __linux__`.

Addresses the underlying issue in #1980 and #1576.