### PR TITLE
X-Plane: bidirectional re-center bridge for in-sim joystick buttons

### DIFF
--- a/api/plugin-api.hpp
+++ b/api/plugin-api.hpp
@@ -170,6 +170,17 @@ struct OTR_API_EXPORT IProtocol : module_status_mixin
     virtual void pose(const double* pose, const double* raw) = 0;
     // return game name or placeholder text
     virtual QString game_name() = 0;
+    // Optional: let the protocol signal back to opentrack that the user
+    // (via the sim/game-side, not a keyboard shortcut) has requested a
+    // re-center. The pipeline polls this once per pose-tick and, when
+    // it returns true, fires set_center() the same way the Center
+    // shortcut does. Default: never request. Protocols that receive
+    // signals from the sim (e.g. proto-wine, whose shared-memory
+    // layout has a center_seq counter bumped by the opentrack.xpl
+    // X-Plane plugin) override this. Call is edge-triggered: a single
+    // bump of center_seq should return true exactly once so the user
+    // doesn't get re-centered every frame after one button press.
+    virtual bool center_requested() { return false; }
 };
 
 struct OTR_API_EXPORT IProtocolDialog : public plugin_api::detail::BaseDialog

--- a/logic/pipeline.cpp
+++ b/logic/pipeline.cpp
@@ -544,6 +544,18 @@ ok:
 
     libs.pProtocol->pose(value, raw);
 
+    // Bridge from sim-side re-center buttons back into opentrack's
+    // centering logic. The protocol (e.g. proto-wine) sees a rising
+    // edge on its signal channel (shared memory bumped by the X-Plane
+    // opentrack.xpl plugin when the user presses a joystick button
+    // bound to the "opentrack/center" command), and returns true
+    // here exactly once per press. This sidesteps the macOS Carbon
+    // global-hotkey limitation where X-Plane's exclusive focus
+    // swallows F-key shortcuts before they reach opentrack's
+    // keyboard-level shortcut system.
+    if (libs.pProtocol->center_requested())
+        set_center(true);
+
     {
         QMutexLocker foo(&mtx);
         m_output_pose = value;

--- a/proto-wine/ftnoir_protocol_wine.cpp
+++ b/proto-wine/ftnoir_protocol_wine.cpp
@@ -60,6 +60,20 @@ void wine::pose(const double *headpose, const double*)
     }
 }
 
+bool wine::center_requested()
+{
+    if (!shm) return false;
+    lck_shm.lock();
+    const int current = shm->center_seq;
+    lck_shm.unlock();
+    if (current == last_seen_center_seq) return false;
+    qDebug() << "proto/wine: center_seq edge"
+             << last_seen_center_seq << "->" << current
+             << "- triggering set_center";
+    last_seen_center_seq = current;
+    return true;
+}
+
 module_status wine::initialize()
 {
 #ifndef OTR_WINE_NO_WRAPPER

--- a/proto-wine/ftnoir_protocol_wine.h
+++ b/proto-wine/ftnoir_protocol_wine.h
@@ -45,6 +45,13 @@ public:
 
     module_status initialize() override;
     void pose(const double* headpose, const double*) override;
+    // Edge-triggered re-center request from the sim side. See
+    // proto-wine/wine-shm.h center_seq comment and the
+    // opentrack.xpl CenterHandler: the X-Plane plugin bumps
+    // center_seq when the user presses a sim-bound button.
+    // Returns true exactly once per bump so opentrack re-centers
+    // on rising edge rather than every frame after the button.
+    bool center_requested() override;
 
     QString game_name() override
     {
@@ -59,6 +66,7 @@ private:
     shm_wrapper lck_shm { WINE_SHM_NAME, WINE_MTX_NAME, sizeof(WineSHM) };
     WineSHM* shm = nullptr;
     settings s;
+    int last_seen_center_seq = 0;
 
 #ifndef OTR_WINE_NO_WRAPPER
     QProcess wrapper;

--- a/proto-wine/wine-shm.h
+++ b/proto-wine/wine-shm.h
@@ -17,4 +17,20 @@ struct WineSHM {
     int gameid, gameid2;
     unsigned char table[8];
     bool stop;
+    // Monotonic counter incremented by the consumer (e.g. the
+    // opentrack.xpl X-Plane plugin) when the user requests a
+    // re-center. opentrack's proto-wine reader compares this against
+    // its last-seen value on each pose() tick and fires a centering
+    // request on increment. Used to let a sim-side button (like a
+    // Honeycomb yoke button bound to an X-Plane command) recenter
+    // opentrack without needing the game's keystrokes to survive
+    // its own focus-grabbing - Carbon global hotkeys don't fire when
+    // X-Plane has exclusive focus on macOS, so keyboard-based
+    // shortcut paths (Enjoyable remapping to F-keys, etc.) don't
+    // work mid-flight.
+    //
+    // Defined at the end of the struct so older consumers that only
+    // know the original layout (first 4 fields) still read/write the
+    // same offsets for pose data - backward-compatible extension.
+    int center_seq;
 };

--- a/x-plane-plugin/plugin.c
+++ b/x-plane-plugin/plugin.c
@@ -59,6 +59,11 @@ typedef struct WineSHM
     int gameid, gameid2;
     unsigned char table[8];
     bool stop;
+    // Layout must match proto-wine/wine-shm.h exactly. See comment
+    // there for rationale. We bump this counter in our
+    // `opentrack/center` command handler; proto-wine on the other
+    // side polls it and fires a re-center when it changes.
+    int center_seq;
 } volatile WineSHM;
 
 static shm_wrapper* lck_posix = NULL;
@@ -66,6 +71,7 @@ static WineSHM* shm_posix = NULL;
 static void *view_x, *view_y, *view_z, *view_heading, *view_pitch, *view_roll;
 static float offset_x, offset_y, offset_z;
 static XPLMCommandRef track_toggle = NULL, translation_disable_toggle = NULL;
+static XPLMCommandRef center_command = NULL;
 static int track_disabled = 1;
 static int translation_disabled;
 
@@ -169,6 +175,38 @@ static int TranslationToggleHandler(XPLMCommandRef inCommand,
     return 0;
 }
 
+// Command "opentrack/center": signals to opentrack (via the shared-
+// memory center_seq counter) that the user wants to re-center. Bind
+// this command to any joystick button in X-Plane's Settings >
+// Keyboard/Joystick dialog (e.g. a Honeycomb yoke button). When
+// pressed, we bump the counter; opentrack's proto-wine side compares
+// against its last-seen value on the next pose tick and fires a
+// re-center. This path sidesteps the macOS Carbon-global-hotkey
+// limitation where X-Plane's exclusive focus swallows F-key
+// shortcuts before they reach opentrack.
+//
+// Deliberately does NOT call reinit_offset(). Doing so accumulates
+// the current head pose into the local offset every press: opentrack
+// hasn't re-centered yet at this exact moment, so the dataref still
+// reflects the pre-center pose, and reading it as the new baseline
+// adds the not-yet-zeroed pose to the offset. Result: view drifts
+// (typically Y goes up) by the magnitude of your current head pose
+// on every button press. opentrack's own set_center on the next pose
+// tick is the single source of truth for "where is forward"; let it
+// do its job and leave the X-Plane offset alone.
+static int CenterHandler(XPLMCommandRef inCommand,
+                         XPLMCommandPhase inPhase,
+                         void* inRefCon)
+{
+    if (inPhase != xplm_CommandBegin) return 0;
+    if (lck_posix != NULL && shm_posix != NULL) {
+        shm_wrapper_lock(lck_posix);
+        shm_posix->center_seq++;
+        shm_wrapper_unlock(lck_posix);
+    }
+    return 0;
+}
+
 static inline
 void volatile_explicit_bzero(void volatile* restrict ptr, size_t len)
 {
@@ -196,6 +234,7 @@ int XPluginStart (char* outName, char* outSignature, char* outDescription) {
 
     track_toggle = XPLMCreateCommand("opentrack/toggle", "Disable/Enable head tracking");
     translation_disable_toggle = XPLMCreateCommand("opentrack/toggle_translation", "Disable/Enable input translation from opentrack");
+    center_command = XPLMCreateCommand("opentrack/center", "Re-center opentrack's head pose to current orientation");
 
     XPLMRegisterCommandHandler(track_toggle,
                                TrackToggleHandler,
@@ -207,8 +246,13 @@ int XPluginStart (char* outName, char* outSignature, char* outDescription) {
                                1,
                                NULL);
 
+    XPLMRegisterCommandHandler(center_command,
+                               CenterHandler,
+                               1,
+                               NULL);
 
-    if (view_x && view_y && view_z && view_heading && view_pitch && track_toggle && translation_disable_toggle) {
+
+    if (view_x && view_y && view_z && view_heading && view_pitch && track_toggle && translation_disable_toggle && center_command) {
         lck_posix = shm_wrapper_init(WINE_SHM_NAME, WINE_MTX_NAME, sizeof(WineSHM));
         if (lck_posix->mem == MAP_FAILED) {
             fprintf(stderr, "opentrack failed to init SHM!\n");


### PR DESCRIPTION
## Summary

Adds a sim-to-opentrack signal channel so an X-Plane-bindable input (Honeycomb yoke button, throttle, anything in `Settings > Joystick`) can re-center opentrack's pose without the keystroke needing to traverse opentrack's keyboard-shortcut path.

## Why

opentrack's global hotkey system uses `Carbon RegisterEventHotKey` (on macOS) which only receives keyboard events. When X-Plane has exclusive focus — especially fullscreen — it consumes F-keys before the hotkey registration sees them, so keyboard-mapper workarounds (Enjoyable button → F13 → opentrack Center shortcut) silently fail mid-flight. The classic "press the button on my yoke to re-center" UX therefore didn't work on macOS at all.

The clean fix is a sim → opentrack signal channel. Since `proto-wine` already shares a POSIX shared-memory segment with `x-plane-plugin/opentrack.xpl` (used today for pose data flowing the other direction), we extend that segment with a small back-channel.

## Implementation

A new edge-triggered signal on the `IProtocol` interface, with `proto-wine` reading it from the existing shared-memory segment.

| File | Change |
|---|---|
| `api/plugin-api.hpp` | `+ virtual bool IProtocol::center_requested()` (default `false` — every other protocol is unaffected) |
| `logic/pipeline.cpp` | After `pProtocol->pose(...)`, poll `center_requested()` and call `set_center(true)` on rising edge — same path the keyboard shortcut uses |
| `proto-wine/wine-shm.h` | `+ int center_seq` at the **end** of `WineSHM` (struct-tail addition keeps the layout backward-compatible with older `opentrack.xpl` consumers) |
| `proto-wine/ftnoir_protocol_wine.{h,cpp}` | Override `center_requested()` with edge detection — returns `true` exactly once per `shm->center_seq` increment, regardless of how many bumps happened between polls (mash-button coalescing) |
| `x-plane-plugin/plugin.c` | New XPLM command `opentrack/center` ("Re-center opentrack's head pose to current orientation"). Handler atomically bumps `shm_posix->center_seq`. Deliberately does **not** call `reinit_offset()` — that would accumulate the pre-center pose into the X-Plane translation offset; opentrack's own `set_center` on the next pose tick is the single source of truth for "where is forward". |

## How users use it

After updating, in X-Plane: `Settings > Joystick`, search for `opentrack/center`, bind it to any yoke / throttle / panel button. Press it in flight and opentrack re-centers regardless of focus state.

## Compatibility

- New `IProtocol::center_requested()` has a default `false` implementation — existing protocols don't need changes.
- `WineSHM.center_seq` is appended at the end of the struct. Older `opentrack.xpl` builds simply won't write past the original layout, and the new `proto-wine` reads `0` and treats it as "no center requested". New `opentrack.xpl` against an older `proto-wine` writes a field that's just past the older struct end — fine if the SHM segment is sized to the new struct (which the new `proto-wine` does), undefined if mixed across very old binaries. Recommend rebuilding both sides together.
- `qDebug` logging at the rising-edge-detection point in `proto-wine`, useful for verifying the bridge fires without staring at preview deltas.

## Test plan

- [x] Build on macOS arm64 — links cleanly.
- [x] Bind `opentrack/center` to a Honeycomb Alpha yoke button in X-Plane 12. Verify pressing it produces a clean re-center in opentrack while X-Plane is fullscreen-focused (the previous F-key path silently failed here).
- [x] Verify mash-button coalescing — pressing the button rapidly produces exactly one `set_center` per detected sequence-number increment, never multiple stacked re-centers.
- [x] Verify `reinit_offset` is NOT called (translation Y stays put after centering — confirms regression I hit during early prototyping).
- [ ] Other-platform smoke (Linux/Windows): no behaviour change expected — `center_requested()` returns `false` by default elsewhere.

## Notes

Extracted from a larger macOS PSVR support branch so it can be reviewed in isolation. No PSVR or macOS-only code paths.
