### PR TITLE
Improve PaperTracker UX: rename marker distance setting and improve AR display

### DIFF
--- a/tracker-papertracker/html/papertracker-help.html
+++ b/tracker-papertracker/html/papertracker-help.html
@@ -125,7 +125,7 @@
         <h2 id="head">Head / Hat <a href="#top" class="back-link">↑</a></h2>
         <p>These measurements help the software translate marker movement into accurate head movement.</p>
         <p><b>Circumference</b>: Measure around your head or hat at the exact level where the markers are positioned.</p>
-        <p><b>Jawline to marker distance</b>: Measure vertically from your jawline to the marker level, used to determine the pivot point for head tilt and rotation.</p>
+        <p><b>Head joint to marker distance</b>: Measure vertically from where the head joins the spine (roughly in line with the back of the jaw) to the marker level, used to determine the pivot point for head tilt and rotation.</p>
 
         <h1 id="troubleshooting">Troubleshooting <a href="#top" class="back-link">↑</a></h1>
         <p>If the tracking is too jittery you can try the following:</p>

--- a/tracker-papertracker/papertracker-settings.h
+++ b/tracker-papertracker/papertracker-settings.h
@@ -26,7 +26,7 @@ struct papertracker_settings : public opts
     value<int> number_of_markers { b, "number_of_markers", 1 };
     value<int> first_marker_id { b, "first_marker_id", 1 };
     value<double> head_circumference_cm { b, "head_circumference_cm", 60 };
-    value<double> marker_height_cm { b, "marker_height_cm", 20 };
+    value<double> marker_height_cm { b, "marker_height_cm", 15 };
     value<papertracker_dictionary> aruco_dictionary { b, "aruco_dictionary", papertracker_dictionary::PAPERTRACKER_DICT_ARUCO_MIP_36h12 };
     value<QString> camera_name { b, "camera_name", "" };
     value<int> zoom { b, "zoom", 100 };

--- a/tracker-papertracker/papertracker.cpp
+++ b/tracker-papertracker/papertracker.cpp
@@ -651,47 +651,59 @@ bool PaperTracker::markers_disappeared(const std::vector<int> &expected, const s
     return false;
 }
 
-/* Draw a bounding box around the head from dimensions defined in settings.
+/* Draw reference points around the head from dimensions defined in settings.
 */
-void PaperTracker::draw_head_bounding_box(cv::Mat &image)
+void PaperTracker::draw_head_indicator(cv::Mat &image)
 {
     double head_radius = circumference_to_radius(s.head_circumference_cm);
 
-    std::vector<cv::Point3d> box_points = {
+    std::array<cv::Point3d, 8> points = {
+        cv::Point3d(0, 0, 0),
         cv::Point3d(-head_radius, 0, -head_radius),
+        cv::Point3d(head_radius, 0, -head_radius),
         cv::Point3d(-head_radius, 0, head_radius),
         cv::Point3d(head_radius, 0, head_radius),
-        cv::Point3d(head_radius, 0, -head_radius),
-        cv::Point3d(-head_radius, s.marker_height_cm, -head_radius),
-        cv::Point3d(-head_radius, s.marker_height_cm, head_radius),
-        cv::Point3d(head_radius, s.marker_height_cm, head_radius),
-        cv::Point3d(head_radius, s.marker_height_cm, -head_radius)
+        cv::Point3d(head_radius, 0, 0),
+        cv::Point3d(0, head_radius, 0),
+        cv::Point3d(0, 0, head_radius)
     };
 
-    std::vector<cv::Point2d> image_points;
-    cv::projectPoints(box_points, head.rvec, head.tvec, camera_matrix, dist_coeffs, image_points);
+    std::array<cv::Point2d, std::size(points)> image_points;
 
-    const cv::Scalar box_color(0, 255, 0);
-    const cv::Scalar brightness3(1, 1, 1);
-    const cv::Scalar brightness2(0.8, 0.8, 0.8);
+    cv::Mat points_mat(static_cast<int>(points.size()), 1, CV_64FC3, points.data());
+    cv::Mat image_points_mat(static_cast<int>(image_points.size()), 1, CV_64FC2, image_points.data());
+
+    cv::projectPoints(points_mat, head.rvec, head.tvec, camera_matrix, dist_coeffs, image_points_mat);
+
+    const cv::Scalar brightness2(1, 1, 1);
     const cv::Scalar brightness1(0.5, 0.5, 0.5);
 
-    const double line_thickness = std::max(image.cols * PAPERTRACKER_LINE_THICKNESS_FRAME_SCALING_FACTOR, 1.0);
+    const double line_thickness = std::max(image.cols * PAPERTRACKER_LINE_THICKNESS_FRAME_SCALING_FACTOR, 2.0);
+    const double corner_radius = std::max(2 * image.cols * PAPERTRACKER_LINE_THICKNESS_FRAME_SCALING_FACTOR, 2.0);
+    const double origin_radius = std::max(3 * image.cols * PAPERTRACKER_LINE_THICKNESS_FRAME_SCALING_FACTOR, 3.0);
 
-    cv::line(image, image_points[0], image_points[1], box_color * brightness2, line_thickness);
-    cv::line(image, image_points[1], image_points[2], box_color * brightness3, line_thickness);
-    cv::line(image, image_points[2], image_points[3], box_color * brightness2, line_thickness);
-    cv::line(image, image_points[3], image_points[0], box_color * brightness1, line_thickness);
+    // back corners
+    cv::circle(image, image_points[1], corner_radius, cv::Scalar(0, 255, 255) * brightness1, -1);
+    cv::circle(image, image_points[2], corner_radius, cv::Scalar(0, 255, 255) * brightness1, -1);
 
-    cv::line(image, image_points[4], image_points[5], box_color * brightness2, line_thickness);
-    cv::line(image, image_points[5], image_points[6], box_color * brightness3, line_thickness);
-    cv::line(image, image_points[6], image_points[7], box_color * brightness2, line_thickness);
-    cv::line(image, image_points[7], image_points[4], box_color * brightness1, line_thickness);
+    // x axis
+    cv::line(image, image_points[0], image_points[5], cv::Scalar(255, 255, 255), line_thickness * 3);
+    cv::line(image, image_points[0], image_points[5], cv::Scalar(0, 0, 255), line_thickness);
 
-    cv::line(image, image_points[0], image_points[4], box_color * brightness1, line_thickness);
-    cv::line(image, image_points[1], image_points[5], box_color * brightness3, line_thickness);
-    cv::line(image, image_points[2], image_points[6], box_color * brightness3, line_thickness);
-    cv::line(image, image_points[3], image_points[7], box_color * brightness1, line_thickness);
+    // y axis
+    cv::line(image, image_points[0], image_points[6], cv::Scalar(255, 255, 255), line_thickness * 3);
+    cv::line(image, image_points[0], image_points[6], cv::Scalar(0, 255, 0), line_thickness);
+
+    // z axis
+    cv::line(image, image_points[0], image_points[7], cv::Scalar(255, 255, 255), line_thickness * 3);
+    cv::line(image, image_points[0], image_points[7], cv::Scalar(255, 0, 0), line_thickness);
+
+    // origin
+    cv::circle(image, image_points[0], origin_radius, cv::Scalar(0, 0, 255), -1);
+
+    // front corners
+    cv::circle(image, image_points[3], corner_radius, cv::Scalar(0, 255, 255) * brightness2, -1);
+    cv::circle(image, image_points[4], corner_radius, cv::Scalar(0, 255, 255) * brightness2, -1);
 }
 
 /* Draw a border around a marker given its vertices in image space.
@@ -718,27 +730,6 @@ void PaperTracker::draw_marker_border(cv::Mat &image, const std::array<cv::Point
     const auto text_size = cv::getTextSize(ss.str(), cv::FONT_HERSHEY_SIMPLEX, font_scale, line_thickness, nullptr);
 
     cv::putText(image, ss.str(), center - cv::Point2f(text_size.width / 2.0, 0), cv::FONT_HERSHEY_SIMPLEX, font_scale, cv::Scalar(255, 255, 255) - border_color, line_thickness, cv::LINE_AA);
-}
-
-/* Draw coordinate axes for a given pose (rvec/tvec).
-*/
-void PaperTracker::draw_axes(cv::Mat &image, const cv::Vec3d &rvec, const cv::Vec3d &tvec, double axis_length, bool color)
-{
-    std::vector<cv::Point3d> axis_points = {
-        {0, 0, 0},
-        {axis_length, 0, 0},
-        {0, axis_length, 0},
-        {0, 0, axis_length}
-    };
-    
-    std::vector<cv::Point2d> image_points;
-    cv::projectPoints(axis_points, rvec, tvec, camera_matrix, dist_coeffs, image_points);
-
-    const double line_thickness = std::max(image.cols * PAPERTRACKER_LINE_THICKNESS_FRAME_SCALING_FACTOR, 1.0);
-        
-    cv::line(image, image_points[0], image_points[1], color ? cv::Scalar(0, 0, 255) : cv::Scalar(255, 255, 255), line_thickness);
-    cv::line(image, image_points[0], image_points[2], color ? cv::Scalar(0, 255, 0) : cv::Scalar(255, 255, 255), line_thickness);
-    cv::line(image, image_points[0], image_points[3], color ? cv::Scalar(255, 0, 0) : cv::Scalar(255, 255, 255), line_thickness);
 }
 
 /* Update FPS average.
@@ -889,12 +880,10 @@ void PaperTracker::run() {
                 draw_marker_border(frame_mat, marker, marker.id, cv::Scalar(0, 0, 170));
         }
 
-        /* Draw head bounding box and coordinate axes.
+        /* Draw head indicator.
         */
-        if (head.num_handles() > 0) {
-            draw_head_bounding_box(frame_mat);
-            draw_axes(frame_mat, head.rvec, head.tvec, circumference_to_radius(s.head_circumference_cm) * 1.5);
-        }
+        if (head.num_handles() > 0)
+            draw_head_indicator(frame_mat);
 
         /* Update and render FPS indicator.
         */

--- a/tracker-papertracker/papertracker.h
+++ b/tracker-papertracker/papertracker.h
@@ -140,9 +140,8 @@ private:
     cv::Vec3d get_approximate_head_origin(const std::vector<cv::Vec3d> &marker_rvecs, const std::vector<cv::Vec3d> &marker_tvecs);
     cv::Rect2f get_marker_detected_region(const std::vector<marker_detection_info> &markers);
     bool markers_disappeared(const std::vector<int> &expected, const std::vector<marker_detection_info> &detected);
-    void draw_head_bounding_box(cv::Mat &image);
+    void draw_head_indicator(cv::Mat &image);
     void draw_marker_border(cv::Mat &image, const std::array<cv::Point2f, 4> &image_points, int id, const cv::Scalar &marker_border = cv::Scalar(0, 0, 255));
-    void draw_axes(cv::Mat &image, const cv::Vec3d &rvec, const cv::Vec3d &tvec, double axis_length=1, bool color=true);
     void update_fps();
 
     friend class PaperTrackerDialog;

--- a/tracker-papertracker/papertracker.ui
+++ b/tracker-papertracker/papertracker.ui
@@ -167,7 +167,7 @@
       <item row="2" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Jawline to marker distance</string>
+         <string>Head joint to marker distance</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Change the "jawline to marker distance" setting to read "head joint to marker distance" and offer a better explanation of how this needs to be measured. The previous description could be misleading as it wasn't clear from which point along the jawline it should be measured. Additionally, the use of a bounding box for the head's AR display could be misleading as a bounding box that envelops the entire head would yield an incorrect pivot point. I have modified the AR display to better reflect the correct settings.

Finally, in modifying the AR display I discovered another instance of per-frame dynamic allocation, which I have also remedied.