### PR TITLE
papertracker: add cmath header

### DIFF
--- a/tracker-papertracker/anglecoveragetracker.cpp
+++ b/tracker-papertracker/anglecoveragetracker.cpp
@@ -6,6 +6,8 @@
  */
 #include "anglecoveragetracker.h"
 
+#include <cmath>
+
 namespace papertracker {
     AngleCoverageBin::AngleCoverageBin(int pitch_index, int yaw_index)
         : pitch_index(pitch_index), yaw_index(yaw_index)


### PR DESCRIPTION
without the header present I see
```
/home/winston/Code/opentrack/tracker-papertracker/anglecoveragetracker.cpp: In member function ‘papertracker::AngleCoverageBin papertracker::AngleCoverageTracker::get_bin(double, double) const’:
/home/winston/Code/opentrack/tracker-papertracker/anglecoveragetracker.cpp:54:27: error: ‘floor’ was not declared in this scope
   54 |         int pitch_index = floor(pitch / pitch_step);
      |                           ^~~~~
```
on Linux with gcc 15.2.0