### PR TITLE
tracker/neuralnet: raise maximum diagonal FOV to 180 degrees

### DIFF
--- a/tracker-neuralnet/neuralnet-trackercontrols.ui
+++ b/tracker-neuralnet/neuralnet-trackercontrols.ui
@@ -625,7 +625,7 @@ Don't roll or change position.</string>
            <number>35</number>
           </property>
           <property name="maximum">
-           <number>90</number>
+           <number>180</number>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
The diagonal-FOV spinbox is capped at 90 degrees, which is below the
field of view of many wide-angle and fisheye lenses. This raises the
maximum to 180 degrees so users with wide-angle cameras can enter their
lens's actual diagonal FOV. The tracker uses this value to estimate
focal length for the pinhole camera model, so an artificially capped
value produces incorrect depth estimates on wider lenses.

One-line change in the `.ui` file — no code changes.