### PR TITLE
feat: Add auto-centering and stop drift when face tracking is lost

### DIFF
--- a/gui/lang/de_DE.ts
+++ b/gui/lang/de_DE.ts
@@ -418,6 +418,14 @@ Klicke „Kalibrierung löschen“, um jegliche Kalibrierungsdaten der zugehöri
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Constant auto-center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centering speed in degrees/pixels per second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Camera offset</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gui/lang/nl_NL.ts
+++ b/gui/lang/nl_NL.ts
@@ -317,6 +317,14 @@ Press &quot;clear calibration&quot; to remove any calibration data pertaining to
         <translation>Bron</translation>
     </message>
     <message>
+        <source>Constant auto-center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centering speed in degrees/pixels per second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>CSV Data Logging</source>
         <translation>CSV-data loggen</translation>
     </message>

--- a/gui/lang/ru_RU.ts
+++ b/gui/lang/ru_RU.ts
@@ -185,6 +185,14 @@ Press &quot;clear calibration&quot; to remove any calibration data pertaining to
         <translation>Центрирование при запуске</translation>
     </message>
     <message>
+        <source>Constant auto-center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centering speed in degrees/pixels per second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Minimize to tray</source>
         <translation>Настройка трея</translation>
     </message>

--- a/gui/lang/stub.ts
+++ b/gui/lang/stub.ts
@@ -185,6 +185,14 @@ Press &quot;clear calibration&quot; to remove any calibration data pertaining to
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Constant auto-center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centering speed in degrees/pixels per second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Minimize to tray</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gui/lang/zh_CN.ts
+++ b/gui/lang/zh_CN.ts
@@ -189,6 +189,14 @@ Press &quot;clear calibration&quot; to remove any calibration data pertaining to
         <translation>关闭翻译界面</translation>
     </message>
     <message>
+        <source>Constant auto-center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centering speed in degrees/pixels per second</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Minimize to tray</source>
         <translation>最小化到托盘</translation>
     </message>

--- a/gui/options-dialog.cpp
+++ b/gui/options-dialog.cpp
@@ -63,6 +63,8 @@ options_dialog::options_dialog(std::unique_ptr<ITrackerDialog>& tracker_dialog_,
     tie_setting(main.tray_start, ui.tray_start);
 
     tie_setting(main.center_at_startup, ui.center_at_startup);
+    tie_setting(main.auto_center, ui.auto_center);
+    tie_setting(main.auto_center_speed, ui.auto_center_speed);
 
     const centering_state centering_modes[] = {
         center_disabled,

--- a/gui/options-dialog.ui
+++ b/gui/options-dialog.ui
@@ -811,7 +811,7 @@
           <enum>QFrame::Shadow::Sunken</enum>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QCheckBox" name="disable_translation">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
@@ -847,7 +847,46 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="1" column="0">
+           <layout class="QHBoxLayout" name="auto_center_layout">
+            <item>
+             <widget class="QCheckBox" name="auto_center">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Constant auto-center</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="auto_center_speed">
+              <property name="toolTip">
+               <string>Centering speed in degrees/pixels per second</string>
+              </property>
+              <property name="decimals">
+               <number>3</number>
+              </property>
+              <property name="minimum">
+               <double>0.001000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>10.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.010000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.330000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="1">
            <widget class="QLabel" name="label_29">
             <property name="text">
              <string/>

--- a/logic/main-settings.hpp
+++ b/logic/main-settings.hpp
@@ -76,6 +76,9 @@ struct OTR_LOGIC_EXPORT main_settings final
     value<bool> tray_start { b, "start-in-tray", false };
 
     value<bool> center_at_startup { b, "center-at-startup", true };
+    value<bool> auto_center { b, "auto-center", false };
+    value<double> auto_center_speed { b, "auto-center-speed", 0.06 };
+    value<double> auto_center_deadzone { b, "auto-center-deadzone", 1.0 };
     value<centering_state> centering_mode { b, "centering-mode", center_roll_compensated };
     value<int> neck_z { b, "neck-depth", 0 };
     value<bool> neck_enable { b, "neck-enable", false };

--- a/logic/pipeline.cpp
+++ b/logic/pipeline.cpp
@@ -471,6 +471,35 @@ void pipeline::logic()
         maybe_set_center_pose(s.centering_mode, value, own_center_logic);
         nan_check(value);
 
+        if (s.auto_center && s.centering_mode != center_disabled && !own_center_logic) {
+            double dt = auto_center_timer.elapsed_seconds();
+            double speed = s.auto_center_speed; 
+            
+            double max_step = speed * dt;
+            double deadzone = s.auto_center_deadzone;
+            
+            bool updated = false;
+            for (int i = 0; i < 6; i++) {
+                double diff = value(i) - center.P(i);
+                
+                // Dead Zone Core
+                // If within deadzone, don't update this axis.
+                if (std::abs(diff) < deadzone)
+                    continue;
+
+                if (std::abs(diff) > 0.0001) {
+                    center.P(i) += std::clamp(diff, -max_step, max_step);
+                    updated = true;
+                }
+            }
+
+            if (updated) {
+                center.QC = dquat::from_euler(center.P[Pitch], center.P[Yaw], -center.P[Roll]).conjugated();
+                center.QR = dquat::from_euler(center.P[Pitch], center.P[Yaw], 0).conjugated();
+            }
+        }
+        auto_center_timer.start();
+
         {
             nan_check(value);
             auto valueʹ = apply_center(s.centering_mode, value);

--- a/logic/pipeline.cpp
+++ b/logic/pipeline.cpp
@@ -472,15 +472,15 @@ void pipeline::logic()
         nan_check(value);
 
         if (s.auto_center && s.centering_mode != center_disabled && !own_center_logic) {
-            double dt = auto_center_timer.elapsed_seconds();
-            double speed = s.auto_center_speed; 
+            const double dt = auto_center_timer.elapsed_seconds();
+            const double speed = s.auto_center_speed; 
             
-            double max_step = speed * dt;
-            double deadzone = s.auto_center_deadzone;
+            const double max_step = speed * dt;
+            const double deadzone = s.auto_center_deadzone;
             
             bool updated = false;
             for (int i = 0; i < 6; i++) {
-                double diff = value(i) - center.P(i);
+                const double diff = value(i) - center.P(i);
                 
                 // Dead Zone Core
                 // If within deadzone, don't update this axis.

--- a/logic/pipeline.cpp
+++ b/logic/pipeline.cpp
@@ -484,13 +484,11 @@ void pipeline::logic()
                 
                 // Dead Zone Core
                 // If within deadzone, don't update this axis.
-                if (std::abs(diff) < deadzone)
+                if (std::abs(diff) <= deadzone)
                     continue;
 
-                if (std::abs(diff) > 0.0001) {
-                    center.P(i) += std::clamp(diff, -max_step, max_step);
-                    updated = true;
-                }
+                center.P(i) += std::clamp(diff, -max_step, max_step);
+                updated = true;
             }
 
             if (updated) {

--- a/logic/pipeline.hpp
+++ b/logic/pipeline.hpp
@@ -106,6 +106,9 @@ class OTR_LOGIC_EXPORT pipeline : private QThread
     time_units::ms backlog_time {};
 
     bool tracking_started = false;
+    
+    // Auto-centering state
+    Timer auto_center_timer;
 
     static double map(double pos, const Map& axis);
     void logic();

--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.cpp
@@ -580,7 +580,11 @@ void NeuralNetTracker::run()
 
         intrinsics_ = make_intrinsics(grayscale_, settings_);
 
-        detect();
+        bool tracked = detect();
+        {
+            QMutexLocker lck(&mtx_);
+            tracking_valid_ = tracked;
+        }
 
         if (is_visible_)
             preview_.copy_to_widget(*video_widget_);
@@ -631,8 +635,17 @@ void NeuralNetTracker::data(double* data)
     Affine tmp = [&]()
     {
         QMutexLocker lck(&mtx_);
+        if (!tracking_valid_)
+        {
+            for (int i = 0; i < 6; i++)
+                data[i] = std::numeric_limits<double>::quiet_NaN();
+            return Affine{};
+        }
         return last_pose_affine_;
     }();
+
+    if (std::isnan(data[0]))
+        return;
 
     const auto& mx = tmp.R.col(0);
     const auto& my = tmp.R.col(1);

--- a/tracker-neuralnet/ftnoir_tracker_neuralnet.h
+++ b/tracker-neuralnet/ftnoir_tracker_neuralnet.h
@@ -29,6 +29,7 @@
 
 #include <array>
 #include <cinttypes>
+#include <limits>
 #include <memory>
 
 #include <opencv2/core.hpp>
@@ -162,6 +163,7 @@ private:
     QMutex mtx_ = {}; // Protects the pose
     std::optional<QuatPose> last_pose_ = {};
     Affine last_pose_affine_ = {};
+    bool tracking_valid_ = false;
 
     Preview preview_;
     std::unique_ptr<cv_video_widget> video_widget_;


### PR DESCRIPTION
### Description
This PR adds a **Constant auto-center** feature to opentrack, along with tracking-state awareness for the neuralnet tracker to prevent drift when the user is away.

- **Auto-centering:** Slowly pulls the centering offset towards the current pose at an adjustable speed (with a deadzone).
- **Tracker integration:** The neuralnet tracker now outputs NaNs when tracking is lost, which temporarily freezes the auto-centering logic so it doesn't drift.


Closes #1786

---

*Note: This is my first-ever Pull Request! Please let me know if there is anything I should adjust, clean up, or change to match the project's style. Thank you!*
