### PR TITLE
ci: update actions/checkout@v2 to v4

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
     - name: clone opentrack/opentrack
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: clone opentrack/depends
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: opentrack/opentrack-depends
         submodules: true


### PR DESCRIPTION
Updates the CI workflow to use current GitHub-maintained action/runtime versions.

Changes:
- `actions/checkout@v2` -> `actions/checkout@v4`

Validation:
- YAML syntax validated
- Diff scope: `.github/workflows/cmake.yml` only
- No deploy/release/publish steps modified
- No pull_request_target usage