### PR TITLE
ci: update actions/checkout to v7 in cmake workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
     - name: clone opentrack/opentrack
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: true
 
     - name: clone opentrack/depends
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: opentrack/opentrack-depends
         submodules: true


### PR DESCRIPTION
Updates the two checkout steps in the CMake workflow from v4 to v7, the current major.

Changes:
- actions/checkout@v4 -> actions/checkout@v7 (2 occurrences in cmake.yml)

Validation:
- workflow YAML parses after the change
- no other actions in .github/workflows need a bump: cmake.yml uses only checkout for github-maintained actions, the remaining steps are third-party actions pinned by the project

Scope: .github/workflows/cmake.yml only.