### PR TITLE
Fix PaperTracker compilation issue under OpenCV 5

### DIFF
--- a/tracker-papertracker/head.cpp
+++ b/tracker-papertracker/head.cpp
@@ -7,6 +7,11 @@
 #include "head.h"
 #include "papertracker-util.h"
 #include <opencv2/opencv.hpp>
+#if __has_include(<opencv2/calib3d.hpp>)
+#   include <opencv2/calib3d.hpp>
+#else
+#   include <opencv2/calib.hpp>
+#endif
 
 namespace papertracker {
     void Head::set_handle_origin(const cv::Vec3d &origin)

--- a/tracker-papertracker/papertracker-util.cpp
+++ b/tracker-papertracker/papertracker-util.cpp
@@ -7,6 +7,11 @@
 #include "papertracker-util.h"
 #include "config.h"
 #include <opencv2/opencv.hpp>
+#if __has_include(<opencv2/calib3d.hpp>)
+#   include <opencv2/calib3d.hpp>
+#else
+#   include <opencv2/calib.hpp>
+#endif
 #include <math.h>
 #include <optional>
 


### PR DESCRIPTION
Use the correct headers when building against OpenCV 5.